### PR TITLE
Upped have_at_most limits

### DIFF
--- a/spec/advanced_search_spec.rb
+++ b/spec/advanced_search_spec.rb
@@ -116,7 +116,7 @@ describe "advanced search" do
       it "subject NOT congresses and keyword" do
         resp = solr_resp_doc_ids_only({'q'=>"#{subject_query('NOT congresses')} AND #{description_query('IEEE xplore')}"}.merge(solr_args))
         resp.should have_at_least(1200).results
-        resp.should have_at_most(1450).results
+        resp.should have_at_most(1500).results
       end
     end
 


### PR DESCRIPTION
@ndushay 
1) advanced search subject and keyword subject -congresses, keyword IEEE xplore keyword
     Failure/Error: resp.should have_at_most(8500).results
       expected at most 8500 results, got 8513
     # ./spec/advanced_search_spec.rb:113:in `block (4 levels) in <top (required)>'

  2) advanced search subject and keyword subject -congresses, keyword IEEE xplore subject NOT congresses and keyword
     Failure/Error: resp.should have_at_most(1450).results
       expected at most 1450 results, got 1494
     # ./spec/advanced_search_spec.rb:119:in `block (4 levels) in <top (required)>'
