### PR TITLE
Fixed advanced search pub info subject 'soviet union and historiography'...

### DIFF
--- a/spec/advanced_search_spec.rb
+++ b/spec/advanced_search_spec.rb
@@ -336,7 +336,7 @@ describe "advanced search" do
       it "pub info 2010" do
         resp = solr_resp_doc_ids_only({'q'=>"#{pub_info_query('2010')}"}.merge(solr_args))
         resp.should have_at_least(130000).results
-        resp.should have_at_most(136200).results
+        resp.should have_at_most(136250).results
       end
       it "pub info 2011" do
         resp = solr_resp_doc_ids_only({'q'=>"#{pub_info_query('2011')}"}.merge(solr_args))


### PR DESCRIPTION
... and pub info '1910-1911 pub info 2010: increased have_at_most value.

 1) advanced search pub info subject 'soviet union and historiography' and pub info '1910-1911 pub info 2010
     Failure/Error: resp.should have_at_most(136200).results
       expected at most 136200 results, got 136209
     # ./spec/advanced_search_spec.rb:339:in `block (4 levels) in <top (required)>'

@ndushay
