### PR TITLE
Fixed advanced search subject and keyword subject -congresses, keyword I...

### DIFF
--- a/spec/advanced_search_spec.rb
+++ b/spec/advanced_search_spec.rb
@@ -110,7 +110,7 @@ describe "advanced search" do
         resp = solr_resp_doc_ids_only({'q'=>"#{description_query('IEEE xplore')}"}.merge(solr_args))
         resp.should have_the_same_number_of_results_as(solr_resp_ids_from_query("IEEE Xplore"))
         resp.should have_at_least(7650).results
-        resp.should have_at_most(8550).results
+        resp.should have_at_most(8600).results
         resp.should have_fewer_results_than(solr_resp_doc_ids_only({'q'=>"#{description_query('IEEE OR xplore')}"}.merge(solr_args)))
       end
       it "subject NOT congresses and keyword" do


### PR DESCRIPTION
...EEE xplore keyword: increased have_at_most value

1) advanced search subject and keyword subject -congresses, keyword IEEE xplore keyword
     Failure/Error: resp.should have_at_most(8550).results
       expected at most 8550 results, got 8570
     # ./spec/advanced_search_spec.rb:113:in `block (4 levels) in <top (required)>'

@ndushay
