### PR TITLE
Fixed tests

### DIFF
--- a/spec/advanced_search_spec.rb
+++ b/spec/advanced_search_spec.rb
@@ -336,7 +336,7 @@ describe "advanced search" do
       it "pub info 2010" do
         resp = solr_resp_doc_ids_only({'q'=>"#{pub_info_query('2010')}"}.merge(solr_args))
         resp.should have_at_least(130000).results
-        resp.should have_at_most(136250).results
+        resp.should have_at_most(136300).results
       end
       it "pub info 2011" do
         resp = solr_resp_doc_ids_only({'q'=>"#{pub_info_query('2011')}"}.merge(solr_args))

--- a/spec/cjk/japanese_title_spec.rb
+++ b/spec/cjk/japanese_title_spec.rb
@@ -21,9 +21,9 @@ describe "Japanese Title searches", :japanese => true do
     it_behaves_like "matches in vern short titles first", 'title', '仏教', /^(佛|仏)(教|敎).*$/, 7 # title starts w match
     context "w lang limit" do
       # trad
-      it_behaves_like "result size and vern short title matches first", 'title', '佛教', 900, 1210, /(佛|仏)(教|敎)/, 100, lang_limit
+      it_behaves_like "result size and vern short title matches first", 'title', '佛教', 900, 1230, /(佛|仏)(教|敎)/, 100, lang_limit
       # modern
-      it_behaves_like "result size and vern short title matches first", 'title', '仏教', 900, 1210, /(佛|仏)(教|敎)/, 100, lang_limit
+      it_behaves_like "result size and vern short title matches first", 'title', '仏教', 900, 1230, /(佛|仏)(教|敎)/, 100, lang_limit
     end
   end
   context "editorial" do
@@ -118,7 +118,7 @@ describe "Japanese Title searches", :japanese => true do
   context "Study of Buddhism", :jira => ['VUF-2732', 'VUF-2733'] do
     # First char of traditional doesn't translate to first char of modern with ICU traditional->simplified
     # (see also japanese han variants for plain buddhism)
-    it_behaves_like "both scripts get expected result size", 'title', 'traditional', '佛教學', 'modern', '仏教学', 275, 575
+    it_behaves_like "both scripts get expected result size", 'title', 'traditional', '佛教學', 'modern', '仏教学', 275, 585
     it_behaves_like "both scripts get expected result size", 'title', 'traditional', '佛教學', 'modern', '仏教学', 150, 225, lang_limit
     it_behaves_like "matches in vern short titles first", 'title', '佛教學', /(佛|仏)(教|敎)(學|学)/, 15, lang_limit # trad
     it_behaves_like "matches in vern short titles first", 'title', '仏教学', /(佛|仏)(教|敎)(學|学)/, 15, lang_limit # modern

--- a/spec/series_search_spec.rb
+++ b/spec/series_search_spec.rb
@@ -7,7 +7,7 @@ describe "Series Search" do
   it "lecture notes in computer science" do
     resp = solr_resp_doc_ids_only(series_search_args 'lecture notes in computer science')
     resp.should have_at_least(7000).results
-    resp.should have_at_most(8025).results
+    resp.should have_at_most(8150).results
   end
   
   it "Lecture notes in statistics (Springer-Verlag)", :jira => 'VUF-1221' do


### PR DESCRIPTION
Japanese Title searches Study of Buddhism and Japanese Title searches buddhism w lang limit: increased at_most value

Fixed Series Search lecture notes in computer science: increased at_most value

Fixed advanced search pub info subject 'soviet union and historiography' and pub info '1910-1911 pub info 2010: increased at_most limit

@ndushay 
  1) advanced search pub info subject 'soviet union and historiography' and pub info '1910-1911 pub info 2010
     Failure/Error: resp.should have_at_most(136250).results
       expected at most 136250 results, got 136264
     # ./spec/advanced_search_spec.rb:339:in `block (4 levels) in <top (required)>'
  2) Japanese Title searches buddhism w lang limit behaves like result size and vern short title matches first title search has between 900 and 1210 results
     Failure/Error: resp.should have_at_most(max).results
       expected at most 1210 results, got 1215
     Shared Example Group: "result size and vern short title matches first" called from ./spec/cjk/japanese_title_spec.rb:24
     # ./spec/support/shared_examples_cjk.rb:8:in`block (2 levels) in <top (required)>'
  3) Japanese Title searches buddhism w lang limit behaves like result size and vern short title matches first title search has between 900 and 1210 results
     Failure/Error: resp.should have_at_most(max).results
       expected at most 1210 results, got 1215
     Shared Example Group: "result size and vern short title matches first" called from ./spec/cjk/japanese_title_spec.rb:26
     # ./spec/support/shared_examples_cjk.rb:8:in `block (2 levels) in <top (required)>'
  4) Japanese Title searches Study of Buddhism behaves like both scripts get expected result size title search has between 275 and 575 results
     Failure/Error: resp.should have_at_most(max).results
       expected at most 575 results, got 577
     Shared Example Group: "both scripts get expected result size" called from ./spec/cjk/japanese_title_spec.rb:121
     # ./spec/support/shared_examples_cjk.rb:8:in`block (2 levels) in <top (required)>'
  5) Japanese Title searches Study of Buddhism behaves like both scripts get expected result size title search has between 275 and 575 results
     Failure/Error: resp.should have_at_most(max).results
       expected at most 575 results, got 577
     Shared Example Group: "both scripts get expected result size" called from ./spec/cjk/japanese_title_spec.rb:121
     # ./spec/support/shared_examples_cjk.rb:8:in `block (2 levels) in <top (required)>'
  7) Series Search lecture notes in computer science
     Failure/Error: resp.should have_at_most(8025).results
       expected at most 8025 results, got 8094
     # ./spec/series_search_spec.rb:10:in`block (2 levels) in <top (required)>'
