### PR TITLE
Fixed tests by increasing have_exactly and have_at_most values

### DIFF
--- a/spec/advanced_search_spec.rb
+++ b/spec/advanced_search_spec.rb
@@ -116,7 +116,7 @@ describe "advanced search" do
       it "subject NOT congresses and keyword" do
         resp = solr_resp_doc_ids_only({'q'=>"#{subject_query('NOT congresses')} AND #{description_query('IEEE xplore')}"}.merge(solr_args))
         resp.should have_at_least(1200).results
-        resp.should have_at_most(1500).results
+        resp.should have_at_most(1550).results
       end
     end
 
@@ -336,12 +336,12 @@ describe "advanced search" do
       it "pub info 2010" do
         resp = solr_resp_doc_ids_only({'q'=>"#{pub_info_query('2010')}"}.merge(solr_args))
         resp.should have_at_least(130000).results
-        resp.should have_at_most(136400).results
+        resp.should have_at_most(136500).results
       end
       it "pub info 2011" do
         resp = solr_resp_doc_ids_only({'q'=>"#{pub_info_query('2011')}"}.merge(solr_args))
         resp.should have_at_least(120000).results
-        resp.should have_at_most(125100).results
+        resp.should have_at_most(125300).results
       end
       it "subject and pub info 2010" do
         resp = solr_resp_doc_ids_only({'q'=>"#{subject_query('soviet union and historiography')} AND #{pub_info_query('2010')}"}.merge(solr_args))

--- a/spec/cjk/japanese_everything_spec.rb
+++ b/spec/cjk/japanese_everything_spec.rb
@@ -100,7 +100,7 @@ describe "Japanese Everything Searches", :japanese => true do
   end
 
   context "seven wonders 七不思議", :jira => 'VUF-2710' do
-    it_behaves_like "result size and vern short title matches first", 'everything', '七不思議', 3, 3, /七不思議/, 1
+    it_behaves_like "result size and vern short title matches first", 'everything', '七不思議', 4, 4, /七不思議/, 1
   end
 
   context "seven wonders of sassafras springs  ササフラス・スプリングスの七不思議", :jira => 'VUF-2709' do


### PR DESCRIPTION
@ndushay
1) advanced search subject and keyword subject -congresses, keyword IEEE xplore subject NOT congresses and keyword
     Failure/Error: resp.should have_at_most(1500).results
       expected at most 1500 results, got 1501
     # ./spec/advanced_search_spec.rb:119:in `block (4 levels) in <top (required)>'

  2) advanced search pub info subject 'soviet union and historiography' and pub info '1910-1911 pub info 2010
     Failure/Error: resp.should have_at_most(136400).results
       expected at most 136400 results, got 136478
     # ./spec/advanced_search_spec.rb:339:in `block (4 levels) in <top (required)>'

  3) advanced search pub info subject 'soviet union and historiography' and pub info '1910-1911 pub info 2011
     Failure/Error: resp.should have_at_most(125100).results
       expected at most 125100 results, got 125244
     # ./spec/advanced_search_spec.rb:344:in `block (4 levels) in <top (required)>'

  4) Japanese Everything Searches seven wonders 七不思議 behaves like result size and vern short title matches first everything search has 3 results
     Failure/Error: resp.should have_exactly(min).results
       expected 3 results, got 4
     Shared Example Group: "result size and vern short title matches first" called from ./spec/cjk/japanese_everything_spec.rb:103
     # ./spec/support/shared_examples_cjk.rb:5:in `block (2 levels) in <top (required)>'
