### PR TITLE
Fixed Chinese Everything history research no spaces behaves like both sc...

### DIFF
--- a/spec/cjk/chinese_everything_spec.rb
+++ b/spec/cjk/chinese_everything_spec.rb
@@ -45,7 +45,7 @@ describe "Chinese Everything", :chinese => true do
 
   context "history research", :jira => 'VUF-2771' do
     context "no spaces" do
-      it_behaves_like "both scripts get expected result size", 'everything', 'traditional', '歷史研究', 'simplified', '历史研究', 5200, 5510
+      it_behaves_like "both scripts get expected result size", 'everything', 'traditional', '歷史研究', 'simplified', '历史研究', 5200, 5515
     end
     context "with space" do
       it_behaves_like "both scripts get expected result size", 'everything', 'traditional', '歷史研究', 'simplified', '历史研究', 5200, 5725


### PR DESCRIPTION
...ripts get expected result size everything search has between 5200 and 5510 results: increased have_at_most limit

1) Chinese Everything history research no spaces behaves like both scripts get expected result size everything search has between 5200 and 5510 results
     Failure/Error: resp.should have_at_most(max).results
       expected at most 5510 results, got 5511
     Shared Example Group: "both scripts get expected result size" called from ./spec/cjk/chinese_everything_spec.rb:48
     # ./spec/support/shared_examples_cjk.rb:8:in `block (2 levels) in <top (required)>'

  2) Chinese Everything history research no spaces behaves like both scripts get expected result size everything search has between 5200 and 5510 results
     Failure/Error: resp.should have_at_most(max).results
       expected at most 5510 results, got 5511
     Shared Example Group: "both scripts get expected result size" called from ./spec/cjk/chinese_everything_spec.rb:48
     # ./spec/support/shared_examples_cjk.rb:8:in `block (2 levels) in <top (required)>'
@ndushay 
