### PR TITLE
Fixed multiple failing tests: increased have_at_most values

### DIFF
--- a/spec/advanced_search_spec.rb
+++ b/spec/advanced_search_spec.rb
@@ -109,8 +109,8 @@ describe "advanced search" do
       it "keyword" do
         resp = solr_resp_doc_ids_only({'q'=>"IEEE xplore"}.merge(solr_args))
         resp.should have_the_same_number_of_results_as(solr_resp_ids_from_query("IEEE Xplore"))
-        resp.should have_at_least(8500).results
-        resp.should have_at_most(8700).results
+        resp.should have_at_least(8600).results
+        resp.should have_at_most(8800).results
         resp.should have_fewer_results_than(solr_resp_doc_ids_only({'q'=>"IEEE OR xplore"}.merge(solr_args)))
       end
       it "subject NOT congresses and keyword" do
@@ -341,8 +341,8 @@ describe "advanced search" do
       end
       it "pub info 2011" do
         resp = solr_resp_doc_ids_only({'q'=>"#{pub_info_query('2011')}"}.merge(solr_args))
-        resp.should have_at_least(124000).results
-        resp.should have_at_most(125500).results
+        resp.should have_at_least(124500).results
+        resp.should have_at_most(125650).results
       end
       it "subject and pub info 2010" do
         resp = solr_resp_doc_ids_only({'q'=>"#{subject_query('soviet union and historiography')} AND #{pub_info_query('2010')}"}.merge(solr_args))

--- a/spec/author_title_spec.rb
+++ b/spec/author_title_spec.rb
@@ -15,8 +15,8 @@ describe "Author-Title Search" do
   it "Beethoven violin concerto", :jira => 'SW-778' do
     q = '"Beethoven, Ludwig van, 1770-1827. Concertos, violin, orchestra, op. 61, D major"'
     resp = solr_response(author_title_search_args(q).merge!({'fl'=>'id,author_person_display', 'facet'=>false}))
-    resp.should have_at_least(90).documents
-    resp.should have_at_most(175).documents
+    resp.should have_at_least(100).documents
+    resp.should have_at_most(185).documents
     resp.should include("author_person_display" => /Beethoven/i).in_each_of_first(5).documents
     resp.should_not include("author_person_display" => /Stowell/i).in_each_of_first(20).documents
   end

--- a/spec/cjk/chinese_everything_spec.rb
+++ b/spec/cjk/chinese_everything_spec.rb
@@ -45,7 +45,7 @@ describe "Chinese Everything", :chinese => true do
 
   context "history research", :jira => 'VUF-2771' do
     context "no spaces" do
-      it_behaves_like "both scripts get expected result size", 'everything', 'traditional', '歷史研究', 'simplified', '历史研究', 5200, 5510
+      it_behaves_like "both scripts get expected result size", 'everything', 'traditional', '歷史研究', 'simplified', '历史研究', 5220, 5530
     end
     context "with space" do
       it_behaves_like "both scripts get expected result size", 'everything', 'traditional', '歷史研究', 'simplified', '历史研究', 5200, 5725

--- a/spec/cjk/chinese_han_variants_spec.rb
+++ b/spec/cjk/chinese_han_variants_spec.rb
@@ -125,8 +125,8 @@ describe "Chinese Han variants", :chinese => true do
   context "敎 654E (variant) => 教 6559 (std trad)" do
     # FIXME:  these do not give the same numbers of results.
     #it_behaves_like "both scripts get expected result size", 'title', 'variant', '敎育', 'std trad', '教育', 3000, 3500, {'fq'=>'language:Japanese'}
-    it_behaves_like "expected result size", 'title', '敎育', 3500, 3520, {'fq'=>'language:Japanese'}  # variant
-    it_behaves_like "expected result size", 'title', '教育', 3500, 3525, {'fq'=>'language:Japanese'}  # std trad
+    it_behaves_like "expected result size", 'title', '敎育', 3500, 3525, {'fq'=>'language:Japanese'}  # variant
+    it_behaves_like "expected result size", 'title', '教育', 3500, 3530, {'fq'=>'language:Japanese'}  # std trad
 
   end
   

--- a/spec/cjk/korean_spacing_spec.rb
+++ b/spec/cjk/korean_spacing_spec.rb
@@ -188,7 +188,7 @@ describe "Korean spacing", :korean => true do
 
   context "As I listened" do
     shared_examples_for "good results for 귀를 기울이면" do | query |
-      it_behaves_like "expected result size", 'everything', query, 1, 15
+      it_behaves_like "expected result size", 'everything', query, 1, 20
     end
     context "귀를 기울이면 (normal spacing)" do
       it_behaves_like "good results for 귀를 기울이면", '경계에서'
@@ -230,7 +230,7 @@ describe "Korean spacing", :korean => true do
   end # Korea today
   context "on the borderline" do
     shared_examples_for "good results for 경계에서" do | query |
-      it_behaves_like "good results for query", 'everything', query, 7, 15, '8838252', 1
+      it_behaves_like "good results for query", 'everything', query, 7, 20, '8838252', 1
     end
     context "경계에서 (normal spacing)" do
       it_behaves_like "good results for 경계에서", '경계에서'

--- a/spec/default_req_handler_spec.rb
+++ b/spec/default_req_handler_spec.rb
@@ -2,10 +2,10 @@ require 'spec_helper'
 
 describe "Default Request Handler" do
   
-  it "q of 'Buddhism' should get 8,500-10,650 results", :jira => 'VUF-160' do
+  it "q of 'Buddhism' should get 8,500-10,675 results", :jira => 'VUF-160' do
     resp = solr_resp_ids_from_query 'Buddhism'
     resp.should have_at_least(8500).documents
-    resp.should have_at_most(10650).documents
+    resp.should have_at_most(10675).documents
   end
   
   it "q of 'String quartets Parts' and variants should be plausible", :jira => 'VUF-390' do

--- a/spec/series_search_spec.rb
+++ b/spec/series_search_spec.rb
@@ -7,7 +7,7 @@ describe "Series Search" do
   it "lecture notes in computer science" do
     resp = solr_resp_doc_ids_only(series_search_args 'lecture notes in computer science')
     resp.should have_at_least(7000).results
-    resp.should have_at_most(8150).results
+    resp.should have_at_most(8200).results
   end
   
   it "Lecture notes in statistics (Springer-Verlag)", :jira => 'VUF-1221' do

--- a/spec/synonym_spec.rb
+++ b/spec/synonym_spec.rb
@@ -177,7 +177,7 @@ describe "Tests for synonyms.txt used by Solr SynonymFilterFactory" do
       it "c# minor" do
         resp = solr_response({'q' => 'c# minor', 'fl'=>'id,title_display', 'facet'=>false})
         resp.should include("title_display" => /c(#|♯|\-sharp| sharp) minor/i).in_each_of_first(20).documents
-        resp.should have_at_most(1800).documents
+        resp.should have_at_most(1900).documents
         resp.should have_the_same_number_of_results_as(solr_resp_ids_from_query('C♯ minor'))
         resp.should have_the_same_number_of_results_as(solr_resp_ids_from_query('C-sharp minor'))
         # would also match  c ... minor ... sharp
@@ -268,7 +268,7 @@ describe "Tests for synonyms.txt used by Solr SynonymFilterFactory" do
         it "B sharp - title" do
           resp = solr_resp_doc_ids_only(title_search_args('b sharp'))
           resp.should include('8156248').as_first # Geo B. Sharp
-          resp.should have_at_most(700).documents
+          resp.should have_at_most(725).documents
         end
         it "paul f sharp", :fixme => true do
           # from solr logs - doesn't work because it's paul frederic sharp


### PR DESCRIPTION
@ndushay 

  1) advanced search subject and keyword subject -congresses, keyword IEEE xplore keyword
     Failure/Error: resp.should have_at_most(8700).results
       expected at most 8700 results, got 8750
     # ./spec/advanced_search_spec.rb:113:in `block (4 levels) in <top (required)>'

  2) advanced search pub info subject 'soviet union and historiography' and pub info '1910-1911 pub info 2011
     Failure/Error: resp.should have_at_most(125500).results
       expected at most 125500 results, got 125595
     # ./spec/advanced_search_spec.rb:344:in `block (4 levels) in <top (required)>'

  3) Author-Title Search Beethoven violin concerto
     Failure/Error: resp.should have_at_most(175).documents
       expected at most 175 documents, got 180
     # ./spec/author_title_spec.rb:19:in `block (2 levels) in <top (required)>'

  4) Chinese Everything history research no spaces behaves like both scripts get expected result size everything search has between 5200 and 5515 results
     Failure/Error: resp.should have_at_most(max).results
       expected at most 5515 results, got 5521
     Shared Example Group: "both scripts get expected result size" called from ./spec/cjk/chinese_everything_spec.rb:48
     # ./spec/support/shared_examples_cjk.rb:8:in `block (2 levels) in <top (required)>'

  5) Chinese Everything history research no spaces behaves like both scripts get expected result size everything search has between 5200 and 5515 results
     Failure/Error: resp.should have_at_most(max).results
       expected at most 5515 results, got 5521
     Shared Example Group: "both scripts get expected result size" called from ./spec/cjk/chinese_everything_spec.rb:48
     # ./spec/support/shared_examples_cjk.rb:8:in `block (2 levels) in <top (required)>'

  6) Korean spacing As I listened 귀를 기울이면 (normal spacing) behaves like good results for 귀를 기울이면 behaves like expected result size everything search has between 1 and 15 results
     Failure/Error: resp.should have_at_most(max).results
       expected at most 15 results, got 16
     Shared Example Group: "expected result size" called from ./spec/cjk/korean_spacing_spec.rb:191
     # ./spec/support/shared_examples_cjk.rb:8:in `block (2 levels) in <top (required)>'

  7) Korean spacing on the borderline 경계에서 (normal spacing) behaves like good results for 경계에서 behaves like good results for query everything search has between 7 and 15 results
     Failure/Error: resp.should have_at_most(max).results
       expected at most 15 results, got 16
     Shared Example Group: "good results for query" called from ./spec/cjk/korean_spacing_spec.rb:233
     # ./spec/support/shared_examples_cjk.rb:8:in `block (2 levels) in <top (required)>'

  8) Tests for synonyms.txt used by Solr SynonymFilterFactory musical keys sharp keys c# minor
     Failure/Error: resp.should have_at_most(1800).documents
       expected at most 1800 documents, got 1830
     # ./spec/synonym_spec.rb:180:in `block (4 levels) in <top (required)>'

  9) Tests for synonyms.txt used by Solr SynonymFilterFactory musical keys sharp keys should not reduce perceived precision for reasonable non-musical searches with x sharp (space) B sharp - title
     Failure/Error: resp.should have_at_most(700).documents
       expected at most 700 documents, got 705
     # ./spec/synonym_spec.rb:271:in `block (5 levels) in <top (required)>'

1) Chinese Han variants 敎 654E (variant) => 教 6559 (std trad) behaves like expected result size title search has between 3500 and 3520 results
     Failure/Error: resp.should have_at_most(max).results
       expected at most 3520 results, got 3524
     Shared Example Group: "expected result size" called from ./spec/cjk/chinese_han_variants_spec.rb:128
     # ./spec/support/shared_examples_cjk.rb:8:in `block (2 levels) in <top (required)>'

  2) Chinese Han variants 敎 654E (variant) => 教 6559 (std trad) behaves like expected result size title search has between 3500 and 3525 results
     Failure/Error: resp.should have_at_most(max).results
       expected at most 3525 results, got 3526
     Shared Example Group: "expected result size" called from ./spec/cjk/chinese_han_variants_spec.rb:129
     # ./spec/support/shared_examples_cjk.rb:8:in `block (2 levels) in <top (required)>'

  3) Default Request Handler q of 'Buddhism' should get 8,500-10,650 results
     Failure/Error: resp.should have_at_most(10650).documents
       expected at most 10650 documents, got 10662
     # ./spec/default_req_handler_spec.rb:8:in `block (2 levels) in <top (required)>'

```
1) Series Search lecture notes in computer science
 Failure/Error: resp.should have_at_most(8150).results
   expected at most 8150 results, got 8151
 # ./spec/series_search_spec.rb:10:in `block (2 levels) in <top (required)>'
```
