### PR TITLE
Fixed multiple failing tests: increased have_at_most value

### DIFF
--- a/spec/advanced_search_spec.rb
+++ b/spec/advanced_search_spec.rb
@@ -109,8 +109,8 @@ describe "advanced search" do
       it "keyword" do
         resp = solr_resp_doc_ids_only({'q'=>"IEEE xplore"}.merge(solr_args))
         resp.should have_the_same_number_of_results_as(solr_resp_ids_from_query("IEEE Xplore"))
-        resp.should have_at_least(8600).results
-        resp.should have_at_most(8800).results
+        resp.should have_at_least(8650).results
+        resp.should have_at_most(8850).results
         resp.should have_fewer_results_than(solr_resp_doc_ids_only({'q'=>"IEEE OR xplore"}.merge(solr_args)))
       end
       it "subject NOT congresses and keyword" do
@@ -341,8 +341,8 @@ describe "advanced search" do
       end
       it "pub info 2011" do
         resp = solr_resp_doc_ids_only({'q'=>"#{pub_info_query('2011')}"}.merge(solr_args))
-        resp.should have_at_least(124500).results
-        resp.should have_at_most(125650).results
+        resp.should have_at_least(124600).results
+        resp.should have_at_most(125750).results
       end
       it "subject and pub info 2010" do
         resp = solr_resp_doc_ids_only({'q'=>"#{subject_query('soviet union and historiography')} AND #{pub_info_query('2010')}"}.merge(solr_args))
@@ -400,7 +400,7 @@ describe "advanced search" do
       it "before topics selected" do
         resp = solr_resp_doc_ids_only({'fq' => 'format:("Video"), language:("English"), building_facet:("Green")', 'q'=>'collection:*'}.merge(solr_args))
         resp.should have_at_least(35000).results
-        resp.should have_at_most(35300).results
+        resp.should have_at_most(35350).results
       end
       it "add topic feature films" do
         resp = solr_resp_doc_ids_only({'fq' => 'format:("Video"), language:("English"), building_facet:("Green"), topic_facet:("Feature films")', 'q'=>'collection:*'}.merge(solr_args))

--- a/spec/cjk/chinese_han_variants_spec.rb
+++ b/spec/cjk/chinese_han_variants_spec.rb
@@ -125,7 +125,7 @@ describe "Chinese Han variants", :chinese => true do
   context "敎 654E (variant) => 教 6559 (std trad)" do
     # FIXME:  these do not give the same numbers of results.
     #it_behaves_like "both scripts get expected result size", 'title', 'variant', '敎育', 'std trad', '教育', 3000, 3500, {'fq'=>'language:Japanese'}
-    it_behaves_like "expected result size", 'title', '敎育', 3500, 3525, {'fq'=>'language:Japanese'}  # variant
+    it_behaves_like "expected result size", 'title', '敎育', 3500, 3535, {'fq'=>'language:Japanese'}  # variant
     it_behaves_like "expected result size", 'title', '教育', 3500, 3530, {'fq'=>'language:Japanese'}  # std trad
 
   end


### PR DESCRIPTION
  1) advanced search subject and keyword subject -congresses, keyword IEEE xplore keyword
     Failure/Error: resp.should have_at_most(8800).results
       expected at most 8800 results, got 8809
     # ./spec/advanced_search_spec.rb:113:in `block (4 levels) in <top (required)>'

  2) advanced search pub info subject 'soviet union and historiography' and pub info '1910-1911 pub info 2011
     Failure/Error: resp.should have_at_most(125650).results
       expected at most 125650 results, got 125673
     # ./spec/advanced_search_spec.rb:345:in `block (4 levels) in <top (required)>'

  3) advanced search facets format video, location green, language english before topics selected
     Failure/Error: resp.should have_at_most(35300).results
       expected at most 35300 results, got 35302
     # ./spec/advanced_search_spec.rb:403:in `block (4 levels) in <top (required)>'

  4) Chinese Han variants 敎 654E (variant) => 教 6559 (std trad) behaves like expected result size title search has between 3500 and 3525 results
     Failure/Error: resp.should have_at_most(max).results
       expected at most 3525 results, got 3527
     Shared Example Group: "expected result size" called from ./spec/cjk/chinese_han_variants_spec.rb:128
     # ./spec/support/shared_examples_cjk.rb:8:in `block (2 levels) in <top (required)>'

  5) advanced search pub info subject 'soviet union and historiography' and pub info '1910-1911 pub info 2011
     Failure/Error: resp.should have_at_most(125700).results
       expected at most 125700 results, got 125721
     # ./spec/advanced_search_spec.rb:345:in `block (4 levels) in <top (required)>'

@ndushay
