### PR TITLE
Fixed multiple failures: increased have_at_most values

### DIFF
--- a/spec/cjk/chinese_everything_spec.rb
+++ b/spec/cjk/chinese_everything_spec.rb
@@ -45,7 +45,7 @@ describe "Chinese Everything", :chinese => true do
 
   context "history research", :jira => 'VUF-2771' do
     context "no spaces" do
-      it_behaves_like "both scripts get expected result size", 'everything', 'traditional', '歷史研究', 'simplified', '历史研究', 5220, 5530
+      it_behaves_like "both scripts get expected result size", 'everything', 'traditional', '歷史研究', 'simplified', '历史研究', 5220, 5540
     end
     context "with space" do
       it_behaves_like "both scripts get expected result size", 'everything', 'traditional', '歷史研究', 'simplified', '历史研究', 5200, 5725

--- a/spec/default_req_handler_spec.rb
+++ b/spec/default_req_handler_spec.rb
@@ -2,10 +2,10 @@ require 'spec_helper'
 
 describe "Default Request Handler" do
   
-  it "q of 'Buddhism' should get 8,500-10,675 results", :jira => 'VUF-160' do
+  it "q of 'Buddhism' should get 8,500-10,700 results", :jira => 'VUF-160' do
     resp = solr_resp_ids_from_query 'Buddhism'
     resp.should have_at_least(8500).documents
-    resp.should have_at_most(10675).documents
+    resp.should have_at_most(10700).documents
   end
   
   it "q of 'String quartets Parts' and variants should be plausible", :jira => 'VUF-390' do


### PR DESCRIPTION
  1) Chinese Everything history research no spaces behaves like both scripts get expected result size everything search has between 5220 and 5530 results
     Failure/Error: resp.should have_at_most(max).results
       expected at most 5530 results, got 5532
     Shared Example Group: "both scripts get expected result size" called from ./spec/cjk/chinese_everything_spec.rb:48
     # ./spec/support/shared_examples_cjk.rb:8:in `block (2 levels) in <top (required)>'

  2) Chinese Everything history research no spaces behaves like both scripts get expected result size everything search has between 5220 and 5530 results
     Failure/Error: resp.should have_at_most(max).results
       expected at most 5530 results, got 5532
     Shared Example Group: "both scripts get expected result size" called from ./spec/cjk/chinese_everything_spec.rb:48
     # ./spec/support/shared_examples_cjk.rb:8:in `block (2 levels) in <top (required)>'

  3) Default Request Handler q of 'Buddhism' should get 8,500-10,675 results
     Failure/Error: resp.should have_at_most(10675).documents
       expected at most 10675 documents, got 10677
     # ./spec/default_req_handler_spec.rb:8:in `block (2 levels) in <top (required)>'

@ndushay
