### PR TITLE
Added gemnasium badge to readme and fixed 4 failure by increasing the have_at_most values

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -1,5 +1,7 @@
 = SearchWorks Solr Index Tests
 
+{<img src="https://gemnasium.com/sul-dlss/sw_index_tests.png" alt="Dependency Status" />}[https://gemnasium.com/sul-dlss/sw_index_tests] 
+
 A ruby "application" for testing the Stanford University Libraries SearchWorks Solr index, using rspec-solr and rsolr gems.  
 
 The main reason this is in publicly accessible web space is to allow it to serve as an exemplar for folks who want to use rspec-solr or who want to figure out a way to automate testing searches against a Solr index.

--- a/spec/advanced_search_spec.rb
+++ b/spec/advanced_search_spec.rb
@@ -109,8 +109,8 @@ describe "advanced search" do
       it "keyword" do
         resp = solr_resp_doc_ids_only({'q'=>"IEEE xplore"}.merge(solr_args))
         resp.should have_the_same_number_of_results_as(solr_resp_ids_from_query("IEEE Xplore"))
-        resp.should have_at_least(8650).results
-        resp.should have_at_most(8850).results
+        resp.should have_at_least(8700).results
+        resp.should have_at_most(8900).results
         resp.should have_fewer_results_than(solr_resp_doc_ids_only({'q'=>"IEEE OR xplore"}.merge(solr_args)))
       end
       it "subject NOT congresses and keyword" do
@@ -341,8 +341,8 @@ describe "advanced search" do
       end
       it "pub info 2011" do
         resp = solr_resp_doc_ids_only({'q'=>"#{pub_info_query('2011')}"}.merge(solr_args))
-        resp.should have_at_least(124600).results
-        resp.should have_at_most(125750).results
+        resp.should have_at_least(124700).results
+        resp.should have_at_most(125850).results
       end
       it "subject and pub info 2010" do
         resp = solr_resp_doc_ids_only({'q'=>"#{subject_query('soviet union and historiography')} AND #{pub_info_query('2010')}"}.merge(solr_args))

--- a/spec/cjk/korean_spacing_spec.rb
+++ b/spec/cjk/korean_spacing_spec.rb
@@ -241,7 +241,7 @@ describe "Korean spacing", :korean => true do
   end # on the borderline
   context "World Inside Korea" do
     shared_examples_for "good results for 한국속의 세계" do | query |
-      it_behaves_like "good results for query", 'everything', query, 12, 475, '7906866', 1
+      it_behaves_like "good results for query", 'everything', query, 12, 500, '7906866', 1
     end
     context "한국속의 세계 (normal spacing)" do
       it_behaves_like "good results for 한국속의 세계", '한국속의 세계'

--- a/spec/cjk/korean_unigram_spec.rb
+++ b/spec/cjk/korean_unigram_spec.rb
@@ -5,7 +5,7 @@ describe "Korean: Unigram Searches", :korean => true do
   # from email from Vitus, Aug 20, 2012
 
   context "title  창 (window)" do
-    it_behaves_like "expected result size", 'title', '창', 550, 640
+    it_behaves_like "expected result size", 'title', '창', 550, 650
     before(:all) do
       @resp = solr_response({'q'=>cjk_q_arg('title', '창'), 'fl'=>'id,vern_title_245a_display', 'facet'=>false} )
     end


### PR DESCRIPTION
  1) advanced search subject and keyword subject -congresses, keyword IEEE xplore keyword
     Failure/Error: resp.should have_at_most(8850).results
       expected at most 8850 results, got 8854
     # ./spec/advanced_search_spec.rb:113:in `block (4 levels) in <top (required)>'

  2) advanced search pub info subject 'soviet union and historiography' and pub info '1910-1911 pub info 2011
     Failure/Error: resp.should have_at_most(125750).results
       expected at most 125750 results, got 125763
     # ./spec/advanced_search_spec.rb:345:in `block (4 levels) in <top (required)>'

  3) Korean spacing World Inside Korea  (spacing in catalog) behaves like good results for 한국속의 세계 behaves like good results for query everything search has between 12 and 475 results
     Failure/Error: resp.should have_at_most(max).results
       expected at most 475 results, got 476
     Shared Example Group: "good results for query" called from ./spec/cjk/korean_spacing_spec.rb:244
     # ./spec/support/shared_examples_cjk.rb:8:in `block (2 levels) in <top (required)>'

  4) Korean: Unigram Searches title  창 (window) behaves like expected result size title search has between 550 and 640 results
     Failure/Error: resp.should have_at_most(max).results
       expected at most 640 results, got 641
     Shared Example Group: "expected result size" called from ./spec/cjk/korean_unigram_spec.rb:8
     # ./spec/support/shared_examples_cjk.rb:8:in `block (2 levels) in <top (required)>'

@ndushay
