### PR TITLE
Fixed multiple failures by increasing have_at_most values

### DIFF
--- a/spec/advanced_search_spec.rb
+++ b/spec/advanced_search_spec.rb
@@ -337,7 +337,7 @@ describe "advanced search" do
       it "pub info 2010" do
         resp = solr_resp_doc_ids_only({'q'=>"#{pub_info_query('2010')}"}.merge(solr_args))
         resp.should have_at_least(136200).results
-        resp.should have_at_most(137000).results
+        resp.should have_at_most(137010).results
       end
       it "pub info 2011" do
         resp = solr_resp_doc_ids_only({'q'=>"#{pub_info_query('2011')}"}.merge(solr_args))

--- a/spec/cjk/chinese_everything_spec.rb
+++ b/spec/cjk/chinese_everything_spec.rb
@@ -45,7 +45,7 @@ describe "Chinese Everything", :chinese => true do
 
   context "history research", :jira => 'VUF-2771' do
     context "no spaces" do
-      it_behaves_like "both scripts get expected result size", 'everything', 'traditional', '歷史研究', 'simplified', '历史研究', 5220, 5540
+      it_behaves_like "both scripts get expected result size", 'everything', 'traditional', '歷史研究', 'simplified', '历史研究', 5220, 5550
     end
     context "with space" do
       it_behaves_like "both scripts get expected result size", 'everything', 'traditional', '歷史研究', 'simplified', '历史研究', 5200, 5725

--- a/spec/cjk/chinese_han_variants_spec.rb
+++ b/spec/cjk/chinese_han_variants_spec.rb
@@ -138,7 +138,7 @@ describe "Chinese Han variants", :chinese => true do
     # FIXME:  these do not give the same numbers of results.
     #it_behaves_like "both scripts get expected result size", 'title', 'variant', '硏究', 'std trad', '研究', 14750, 15250, {'fq'=>'language:Japanese'}
     it_behaves_like "expected result size", 'title', '硏究', 14750, 15250, {'fq'=>'language:Japanese'}  # variant
-    it_behaves_like "expected result size", 'title', '研究', 14750, 15250, {'fq'=>'language:Japanese'}  # std trad
+    it_behaves_like "expected result size", 'title', '研究', 14750, 15260, {'fq'=>'language:Japanese'}  # std trad
   end
 
   context "緖 7DD6 (variant) => 緒 7DD2 (std trad)" do

--- a/spec/cjk/korean_spacing_spec.rb
+++ b/spec/cjk/korean_spacing_spec.rb
@@ -206,7 +206,7 @@ describe "Korean spacing", :korean => true do
 
   context "Korean economy at the turning point" do
     shared_examples_for "good results for 전환기의 한국경제" do | query |
-      it_behaves_like "good results for query", 'everything', query, 3, 525, '7132960', 1
+      it_behaves_like "good results for query", 'everything', query, 3, 530, '7132960', 1
     end
     context "전환기의 한국경제  (normal spacing)" do
       it_behaves_like "good results for 전환기의 한국경제", '전환기의 한국경제'


### PR DESCRIPTION
1) Chinese Everything history research no spaces behaves like both scripts get expected result size everything search has between 5220 and 5540 results
     Failure/Error: resp.should have_at_most(max).results
       expected at most 5540 results, got 5544
     Shared Example Group: "both scripts get expected result size" called from ./spec/cjk/chinese_everything_spec.rb:48
     # ./spec/support/shared_examples_cjk.rb:8:in `block (2 levels) in <top (required)>'

  2) Chinese Everything history research no spaces behaves like both scripts get expected result size everything search has between 5220 and 5540 results
     Failure/Error: resp.should have_at_most(max).results
       expected at most 5540 results, got 5544
     Shared Example Group: "both scripts get expected result size" called from ./spec/cjk/chinese_everything_spec.rb:48
     # ./spec/support/shared_examples_cjk.rb:8:in `block (2 levels) in <top (required)>'

  3) Chinese Han variants 硏 784F (variant) => 研 7814 (std trad) behaves like expected result size title search has between 14750 and 15250 results
     Failure/Error: resp.should have_at_most(max).results
       expected at most 15250 results, got 15251
     Shared Example Group: "expected result size" called from ./spec/cjk/chinese_han_variants_spec.rb:141
     # ./spec/support/shared_examples_cjk.rb:8:in `block (2 levels) in <top (required)>'

  4) Korean spacing Korean economy at the turning point 전환기 의 한국 경제 (spacing in catalog) behaves like good results for 전환기의 한국경제 behaves like good results for query everything search has between 3 and 525 results
     Failure/Error: resp.should have_at_most(max).results
       expected at most 525 results, got 528
     Shared Example Group: "good results for query" called from ./spec/cjk/korean_spacing_spec.rb:209
     # ./spec/support/shared_examples_cjk.rb:8:in `block (2 levels) in <top (required)>'

  5) advanced search pub info subject 'soviet union and historiography' and pub info '1910-1911 pub info 2010
     Failure/Error: resp.should have_at_most(137000).results
       expected at most 137000 results, got 137002
     # ./spec/advanced_search_spec.rb:340:in `block (4 levels) in <top (required)>'

@ndushay 
