### PR TITLE
Fixed multiple failures by increasing have_at_most values

### DIFF
--- a/spec/advanced_search_spec.rb
+++ b/spec/advanced_search_spec.rb
@@ -405,7 +405,7 @@ describe "advanced search" do
       it "add topic feature films" do
         resp = solr_resp_doc_ids_only({'fq' => 'format:("Video"), language:("English"), building_facet:("Green"), topic_facet:("Feature films")', 'q'=>'collection:*'}.merge(solr_args))
         resp.should have_at_least(17500).results
-        resp.should have_at_most(18100).results
+        resp.should have_at_most(18200).results
       end
       it "add topic science fiction" do
         resp = solr_resp_doc_ids_only({'fq' => 'format:("Video"), language:("English"), building_facet:("Green"), topic_facet:("Feature films"), topic_facet:("Science fiction films")', 'q'=>'collection:*'}.merge(solr_args))

--- a/spec/author_title_spec.rb
+++ b/spec/author_title_spec.rb
@@ -70,7 +70,7 @@ describe "Author-Title Search" do
     q = '"Beethoven, Ludwig van, 1770-1827. Fidelio (1814)"'
     resp = solr_response(author_title_search_args(q).merge!({'fl'=>'id,author_person_display,title_245a_display', 'facet'=>false}))
     resp.should have_at_least(150).documents
-    resp.should have_at_most(210).documents
+    resp.should have_at_most(250).documents
     resp.should include("author_person_display" => /Beethoven/i).in_each_of_first(20).documents
     resp.should include("title_245a_display" => /fidelio/i).in_each_of_first(2).documents
   end

--- a/spec/cjk/chinese_han_variants_spec.rb
+++ b/spec/cjk/chinese_han_variants_spec.rb
@@ -126,7 +126,7 @@ describe "Chinese Han variants", :chinese => true do
     # FIXME:  these do not give the same numbers of results.
     #it_behaves_like "both scripts get expected result size", 'title', 'variant', '敎育', 'std trad', '教育', 3000, 3500, {'fq'=>'language:Japanese'}
     it_behaves_like "expected result size", 'title', '敎育', 3500, 3535, {'fq'=>'language:Japanese'}  # variant
-    it_behaves_like "expected result size", 'title', '教育', 3500, 3530, {'fq'=>'language:Japanese'}  # std trad
+    it_behaves_like "expected result size", 'title', '教育', 3500, 3550, {'fq'=>'language:Japanese'}  # std trad
 
   end
   
@@ -138,7 +138,7 @@ describe "Chinese Han variants", :chinese => true do
     # FIXME:  these do not give the same numbers of results.
     #it_behaves_like "both scripts get expected result size", 'title', 'variant', '硏究', 'std trad', '研究', 14750, 15250, {'fq'=>'language:Japanese'}
     it_behaves_like "expected result size", 'title', '硏究', 14750, 15750, {'fq'=>'language:Japanese'}  # variant
-    it_behaves_like "expected result size", 'title', '研究', 14750, 15260, {'fq'=>'language:Japanese'}  # std trad
+    it_behaves_like "expected result size", 'title', '研究', 14750, 15450, {'fq'=>'language:Japanese'}  # std trad
   end
 
   context "緖 7DD6 (variant) => 緒 7DD2 (std trad)" do

--- a/spec/cjk/korean_spacing_spec.rb
+++ b/spec/cjk/korean_spacing_spec.rb
@@ -322,7 +322,7 @@ describe "Korean spacing", :korean => true do
   context "hangul + hancha" do
     context "Analysis of Korean economy" do
       shared_examples_for "good results for 韓國經濟의 分析" do | query |
-        it_behaves_like "good results for query", 'everything', query, 5, 90, '6647380', 1
+        it_behaves_like "good results for query", 'everything', query, 5, 100, '6647380', 1
       end
       context "韓國經濟의 分析  (normal spacing)" do
         it_behaves_like "good results for 韓國經濟의 分析", '韓國經濟의 分析 '

--- a/spec/cjk/korean_title_spec.rb
+++ b/spec/cjk/korean_title_spec.rb
@@ -72,7 +72,7 @@ describe "Korean Titles", :korean => true do
       it_behaves_like "good title results for 한국 근대사", '한국 근대사'
     end
     context '"한국 근대사" (phrase)' do
-      it_behaves_like "expected result size", 'title', '"한국 근대사"', 40, 50
+      it_behaves_like "expected result size", 'title', '"한국 근대사"', 40, 60
       it_behaves_like "good title results for 한국 근대사", '"한국 근대사"'
     end
   end # Hangul: Korean modern history   VUF-2722

--- a/spec/synonym_spec.rb
+++ b/spec/synonym_spec.rb
@@ -377,7 +377,7 @@ describe "Tests for synonyms.txt used by Solr SynonymFilterFactory" do
         it "a flat world - title search" do
           resp = solr_response(title_search_args('a flat world').merge!({'fl'=>'id,title_display', 'facet'=>false}))
           resp.should include("title_display" => /a flat world/).in_each_of_first(5).documents
-          resp.should have_at_most(65).documents
+          resp.should have_at_most(75).documents
         end
         it "a bent flat (qs = 1)" do
           resp = solr_resp_ids_from_query('a bent flat')


### PR DESCRIPTION
  1) advanced search facets format video, location green, language english add topic feature films
     Failure/Error: resp.should have_at_most(18100).results
       expected at most 18100 results, got 18102
     # ./spec/advanced_search_spec.rb:408:in `block (4 levels) in <top (required)>'

  2) Chinese Han variants 敎 654E (variant) => 教 6559 (std trad) behaves like expected result size title search has between 3500 and 3530 results
     Failure/Error: resp.should have_at_most(max).results
       expected at most 3530 results, got 3531
     Shared Example Group: "expected result size" called from ./spec/cjk/chinese_han_variants_spec.rb:129
     # ./spec/support/shared_examples_cjk.rb:8:in `block (2 levels) in <top (required)>'

  3) Chinese Han variants 硏 784F (variant) => 研 7814 (std trad) behaves like expected result size title search has between 14750 and 15260 results
     Failure/Error: resp.should have_at_most(max).results
       expected at most 15260 results, got 15262
     Shared Example Group: "expected result size" called from ./spec/cjk/chinese_han_variants_spec.rb:141
     # ./spec/support/shared_examples_cjk.rb:8:in `block (2 levels) in <top (required)>'

  4) Korean spacing hangul + hancha Analysis of Korean economy 韓國 經濟 의 分析 (spacing in catalog) behaves like good results for 韓國經濟의 分析 behaves like good results for query everything search has between 5 and 90 results
     Failure/Error: resp.should have_at_most(max).results
       expected at most 90 results, got 91
     Shared Example Group: "good results for query" called from ./spec/cjk/korean_spacing_spec.rb:325
     # ./spec/support/shared_examples_cjk.rb:8:in `block (2 levels) in <top (required)>'

  5) Korean Titles Hangul: Korean modern history "한국 근대사" (phrase) behaves like expected result size title search has between 40 and 50 results
     Failure/Error: resp.should have_at_most(max).results
       expected at most 50 results, got 51
     Shared Example Group: "expected result size" called from ./spec/cjk/korean_title_spec.rb:75
     # ./spec/support/shared_examples_cjk.rb:8:in `block (2 levels) in <top (required)>'

1) Author-Title Search Beethoven fidelio 1814
     Failure/Error: resp.should have_at_most(210).documents
       expected at most 210 documents, got 214
     # ./spec/author_title_spec.rb:73:in `block (2 levels) in <top (required)>'

  2) Tests for synonyms.txt used by Solr SynonymFilterFactory musical keys flat keys should not reduce perceived precision for reasonable non-musical searches with x flat (space) a flat world - title search
     Failure/Error: resp.should have_at_most(65).documents
       expected at most 65 documents, got 66
     # ./spec/synonym_spec.rb:380:in `block (5 levels) in <top (required)>'
