### PR TITLE
Increased have_at_most values

### DIFF
--- a/spec/cjk/japanese_han_variants_spec.rb
+++ b/spec/cjk/japanese_han_variants_spec.rb
@@ -34,8 +34,8 @@ describe "Japanese Kanji variants", :japanese => true do
       # Second char of traditional doesn't translate to second char of modern with ICU traditional->simplified 
       # FIXME:  these do not give the same numbers of results.
       #it_behaves_like "both scripts get expected result size", 'everything', 'traditional', '江戶', 'modern', '江戸', 1900, 2000
-      it_behaves_like "expected result size", 'everything', '江戶', 1970, 1990  # trad
-      it_behaves_like "expected result size", 'everything', '江戸', 1970, 1990  # modern
+      it_behaves_like "expected result size", 'everything', '江戶', 1970, 2000  # trad
+      it_behaves_like "expected result size", 'everything', '江戸', 1970, 2000  # modern
 
       it_behaves_like "matches in vern short titles first", 'everything', '江戶', /(江戶|江戸)/, 100  # trad
       it_behaves_like "matches in vern short titles first", 'everything', '江戸', /(江戶|江戸)/, 100  # modern

--- a/spec/cjk/korean_unigram_spec.rb
+++ b/spec/cjk/korean_unigram_spec.rb
@@ -5,7 +5,7 @@ describe "Korean: Unigram Searches", :korean => true do
   # from email from Vitus, Aug 20, 2012
 
   context "title  창 (window)" do
-    it_behaves_like "expected result size", 'title', '창', 550, 650
+    it_behaves_like "expected result size", 'title', '창', 550, 675
     before(:all) do
       @resp = solr_response({'q'=>cjk_q_arg('title', '창'), 'fl'=>'id,vern_title_245a_display', 'facet'=>false} )
     end


### PR DESCRIPTION
  1) Japanese Kanji variants modern Kanji != simplified Han Edo (old name for Tokyo) behaves like expected result size everything search has between 1970 and 1990 results
     Failure/Error: resp.should have_at_most(max).results
       expected at most 1990 results, got 1991
     Shared Example Group: "expected result size" called from ./spec/cjk/japanese_han_variants_spec.rb:38
     # ./spec/support/shared_examples_cjk.rb:8:in `block (2 levels) in <top (required)>'

  2) Korean: Unigram Searches title  창 (window) behaves like expected result size title search has between 550 and 650 results
     Failure/Error: resp.should have_at_most(max).results
       expected at most 650 results, got 652
     Shared Example Group: "expected result size" called from ./spec/cjk/korean_unigram_spec.rb:8
     # ./spec/support/shared_examples_cjk.rb:8:in `block (2 levels) in <top (required)>'
