### PR TITLE
Updated have at most value

### DIFF
--- a/spec/advanced_search_spec.rb
+++ b/spec/advanced_search_spec.rb
@@ -341,8 +341,8 @@ describe "advanced search" do
       end
       it "pub info 2011" do
         resp = solr_resp_doc_ids_only({'q'=>"#{pub_info_query('2011')}"}.merge(solr_args))
-        resp.should have_at_least(127000).results
-        resp.should have_at_most(128000).results
+        resp.should have_at_least(127050).results
+        resp.should have_at_most(128050).results
       end
       it "subject and pub info 2010" do
         resp = solr_resp_doc_ids_only({'q'=>"#{subject_query('soviet union and historiography')} AND #{pub_info_query('2010')}"}.merge(solr_args))


### PR DESCRIPTION
1) advanced search pub info subject 'soviet union and historiography' and pub info '1910-1911 pub info 2011
     Failure/Error: resp.should have_at_most(128000).results
       expected at most 128000 results, got 128023
     # ./spec/advanced_search_spec.rb:345:in `block (4 levels) in <top (required)>'
