### PR TITLE
Fixed failures by increasing have at most value

### DIFF
--- a/spec/advanced_search_spec.rb
+++ b/spec/advanced_search_spec.rb
@@ -341,8 +341,8 @@ describe "advanced search" do
       end
       it "pub info 2011" do
         resp = solr_resp_doc_ids_only({'q'=>"#{pub_info_query('2011')}"}.merge(solr_args))
-        resp.should have_at_least(127500).results
-        resp.should have_at_most(128500).results
+        resp.should have_at_least(128000).results
+        resp.should have_at_most(129000).results
       end
       it "subject and pub info 2010" do
         resp = solr_resp_doc_ids_only({'q'=>"#{subject_query('soviet union and historiography')} AND #{pub_info_query('2010')}"}.merge(solr_args))
@@ -399,8 +399,8 @@ describe "advanced search" do
       end
       it "before topics selected" do
         resp = solr_resp_doc_ids_only({'fq' => 'format:("Video"), language:("English"), building_facet:("Green")', 'q'=>'collection:*'}.merge(solr_args))
-        resp.should have_at_least(35300).results
-        resp.should have_at_most(35800).results
+        resp.should have_at_least(35400).results
+        resp.should have_at_most(35900).results
       end
       it "add topic feature films" do
         resp = solr_resp_doc_ids_only({'fq' => 'format:("Video"), language:("English"), building_facet:("Green"), topic_facet:("Feature films")', 'q'=>'collection:*'}.merge(solr_args))


### PR DESCRIPTION
1) advanced search pub info subject 'soviet union and historiography' and pub info '1910-1911 pub info 2011
     Failure/Error: resp.should have_at_most(128500).results
       expected at most 128500 results, got 128674
     # ./spec/advanced_search_spec.rb:345:in `block (4 levels) in <top (required)>'

  2) advanced search facets format video, location green, language english before topics selected
     Failure/Error: resp.should have_at_most(35800).results
       expected at most 35800 results, got 35808
     # ./spec/advanced_search_spec.rb:403:in `block (4 levels) in <top (required)>'