### PR TITLE
Fixed failures by increasing have_at_most values

### DIFF
--- a/spec/cjk/japanese_everything_spec.rb
+++ b/spec/cjk/japanese_everything_spec.rb
@@ -22,8 +22,8 @@ describe "Japanese Everything Searches", :japanese => true do
     # (see also japanese_han_variants_spec)
     # FIXME:  these do not give the same numbers of results.
     #it_behaves_like "both scripts get expected result size", 'everything', 'traditional', '江戶', 'modern', '江戸', 1900, 2000, lang_limit
-    it_behaves_like "expected result size", 'everything', '江戶', 1960, 2000, lang_limit  # trad
-    it_behaves_like "expected result size", 'everything', '江戸', 1960, 2000, lang_limit  # modern
+    it_behaves_like "expected result size", 'everything', '江戶', 1975, 2025, lang_limit  # trad
+    it_behaves_like "expected result size", 'everything', '江戸', 1975, 2025, lang_limit  # modern
 
     it_behaves_like "matches in vern short titles first", 'everything', '江戶', /(江戶|江戸)/, 100, lang_limit  # trad
     it_behaves_like "matches in vern short titles first", 'everything', '江戸', /(江戶|江戸)/, 100, lang_limit # modern

--- a/spec/cjk/korean_spacing_spec.rb
+++ b/spec/cjk/korean_spacing_spec.rb
@@ -150,7 +150,7 @@ describe "Korean spacing", :korean => true do
 
   context "Korean economy" do
     shared_examples_for "good results for 한국경제" do | query |
-      it_behaves_like "expected result size", 'everything', query, 650, 800
+      it_behaves_like "expected result size", 'everything', query, 700, 850
       # no spaces, exact 245a
       it_behaves_like 'best matches first', 'everything', query, '6812133', 7
       # spaces, exact 245a
@@ -241,7 +241,7 @@ describe "Korean spacing", :korean => true do
   end # on the borderline
   context "World Inside Korea" do
     shared_examples_for "good results for 한국속의 세계" do | query |
-      it_behaves_like "good results for query", 'everything', query, 12, 500, '7906866', 1
+      it_behaves_like "good results for query", 'everything', query, 12, 550, '7906866', 1
     end
     context "한국속의 세계 (normal spacing)" do
       it_behaves_like "good results for 한국속의 세계", '한국속의 세계'


### PR DESCRIPTION
  1) Korean spacing Korean economy 한국경제 (no spaces) behaves like good results for 한국경제 behaves like expected result size everything search has between 650 and 800 results
     Failure/Error: resp.should have_at_most(max).results
       expected at most 800 results, got 801
     Shared Example Group: "expected result size" called from ./spec/cjk/korean_spacing_spec.rb:153
     # ./spec/support/shared_examples_cjk.rb:8:in `block (2 levels) in <top (required)>'

  2) Korean spacing World Inside Korea  (spacing in catalog) behaves like good results for 한국속의 세계 behaves like good results for query everything search has between 12 and 500 results
     Failure/Error: resp.should have_at_most(max).results
       expected at most 500 results, got 503
     Shared Example Group: "good results for query" called from ./spec/cjk/korean_spacing_spec.rb:244
     # ./spec/support/shared_examples_cjk.rb:8:in `block (2 levels) in <top (required)>'

  1) Japanese Everything Searches Edo (old name for Tokyo) behaves like expected result size everything search has between 1960 and 2000 results
     Failure/Error: resp.should have_at_most(max).results
       expected at most 2000 results, got 2001
     Shared Example Group: "expected result size" called from ./spec/cjk/japanese_everything_spec.rb:26
     # ./spec/support/shared_examples_cjk.rb:8:in `block (2 levels) in <top (required)>'
