### PR TITLE
Fixed have_at_most values and number of rows for sorting

### DIFF
--- a/spec/advanced_search_spec.rb
+++ b/spec/advanced_search_spec.rb
@@ -399,13 +399,13 @@ describe "advanced search" do
       end
       it "before topics selected" do
         resp = solr_resp_doc_ids_only({'fq' => 'format:("Video"), language:("English"), building_facet:("Green")', 'q'=>'collection:*'}.merge(solr_args))
-        resp.should have_at_least(35500).results
-        resp.should have_at_most(36000).results
+        resp.should have_at_least(35600).results
+        resp.should have_at_most(36100).results
       end
       it "add topic feature films" do
         resp = solr_resp_doc_ids_only({'fq' => 'format:("Video"), language:("English"), building_facet:("Green"), topic_facet:("Feature films")', 'q'=>'collection:*'}.merge(solr_args))
-        resp.should have_at_least(17700).results
-        resp.should have_at_most(18500).results
+        resp.should have_at_least(17750).results
+        resp.should have_at_most(18550).results
       end
       it "add topic science fiction" do
         resp = solr_resp_doc_ids_only({'fq' => 'format:("Video"), language:("English"), building_facet:("Green"), topic_facet:("Feature films"), topic_facet:("Science fiction films")', 'q'=>'collection:*'}.merge(solr_args))

--- a/spec/sort_spec.rb
+++ b/spec/sort_spec.rb
@@ -16,7 +16,7 @@ describe "sorting results" do
 #      resp = solr_response({'fq'=>'format:Book', 'fl'=>'id,pub_date', 'facet'=>false})
 #      year = Time.new.year
 #      resp.should include("pub_date" => /(#{year}|#{year + 1}|#{year + 2})/).in_each_of_first(20).documents
-      resp = solr_response({'fq'=>'format_main_ssim:Book', 'fl'=>'id,pub_date,imprint_display,title_245a_display', 'facet'=>false, 'rows'=>500})
+      resp = solr_response({'fq'=>'format_main_ssim:Book', 'fl'=>'id,pub_date,imprint_display,title_245a_display', 'facet'=>false, 'rows'=>600})
       docs_match_current_year resp
       # _The Bible on Silent Film_ (imprint 2013/ pub_date (008) as 2015) before _The Borders of Race in Colonial South Africa_ (imprint 2013/ pub_date as 2015)
       resp.should include('10343020').before('10343019')


### PR DESCRIPTION
1) advanced search facets format video, location green, language english before topics selected
     Failure/Error: resp.should have_at_most(36000).results
       expected at most 36000 results, got 36037
     # ./spec/advanced_search_spec.rb:403:in `block (4 levels) in <top (required)>'

  2) advanced search facets format video, location green, language english add topic feature films
     Failure/Error: resp.should have_at_most(18500).results
       expected at most 18500 results, got 18509
     # ./spec/advanced_search_spec.rb:408:in `block (4 levels) in <top (required)>'

  3) sorting results empty query with facet format_main_ssim:Book; default sort should be by pub date desc then title asc
     Failure/Error: resp.should include('10343020').before('10343019')
     # ./spec/sort_spec.rb:22:in `block (3 levels) in <top (required)>'