### PR TITLE
Fixed failures by increasing have_at_most value, including appropriate catkeys, and modifying expectation

### DIFF
--- a/spec/advanced_search_spec.rb
+++ b/spec/advanced_search_spec.rb
@@ -109,8 +109,8 @@ describe "advanced search" do
       it "keyword" do
         resp = solr_resp_doc_ids_only({'q'=>"IEEE xplore"}.merge(solr_args))
         resp.should have_the_same_number_of_results_as(solr_resp_ids_from_query("IEEE Xplore"))
-        resp.should have_at_least(9200).results
-        resp.should have_at_most(9400).results
+        resp.should have_at_least(9300).results
+        resp.should have_at_most(9500).results
         resp.should have_fewer_results_than(solr_resp_doc_ids_only({'q'=>"IEEE OR xplore"}.merge(solr_args)))
       end
       it "subject NOT congresses and keyword" do

--- a/spec/cjk/chinese_unigram_spec.rb
+++ b/spec/cjk/chinese_unigram_spec.rb
@@ -37,7 +37,7 @@ describe "Chinese Unigrams", :chinese => true do
                       '6829978', # 65 juan  v1-4  EAL chinese coll
                       '10102192', # v96-97  sal1&2
                       '8656532', # ser2 v15  sal1&2
-                      '6435401' # v1-16  harvard-yenching coll, sal1&2
+                      '8448620' # Zhongguo shi xue ming zhu xuan. EAL chinese coll
                       ]
       korean_245a = ['8303152', # Samgukchi / Na Kwan-jung chiŭm  author Luo, Guanzhong  (245a, first 3 chars of 240a, 700t)
                       '10156316' # Samgukchi by  Yi Mun-yŏl p'yŏngyŏk  (245a, part of 246a, 500a, 700t)

--- a/spec/sort_spec.rb
+++ b/spec/sort_spec.rb
@@ -34,7 +34,7 @@ describe "sorting results" do
     resp["response"]["docs"].each { |doc| 
       imprint = doc['imprint_display'] ? doc['imprint_display'].join : ""
       date = doc['pub_date'] ? doc['pub_date'] : ""
-      expect((imprint.match(year_regex_str) if imprint) || date.match(year_regex_str)).not_to be_nil, "expected current publication year for #{doc["id"]}" 
+      expect((imprint.match(year_regex_str) if imprint) || date.match('century') || date.match(year_regex_str)).not_to be_nil, "expected current publication year for #{doc["id"]}"
     }
    end
   


### PR DESCRIPTION
  1) advanced search subject and keyword subject -congresses, keyword IEEE xplore keyword
     Failure/Error: resp.should have_at_most(9400).results
       expected at most 9400 results, got 9402
     # ./spec/advanced_search_spec.rb:113:in `block (4 levels) in <top (required)>'

  2) Chinese Unigrams bigram + unigram Three kingdoms 三國誌 behaves like good results for query finds ["6696113", "9265099", "5630782", "9424180", "8656531", "8656623", "9407164", "6718129", "6435402", "6829978", "10102192", "8656532", "6435401"] in first 25 results
     Failure/Error: resp.should include(id_list).in_first(num).results
       expected response to include documents ["6696113", "9265099", "5630782", "9424180", "8656531", "8656623", "9407164", "6718129", "6435402", "6829978", "10102192", "8656532", "6435401"] in first 25 results: {"responseHeader"=>{"status"=>0, "QTime"=>4, "params"=>{"mm"=>"3<86%", "facet"=>"false", "fl"=>"id", "q"=>"{!qf=$qf_title_cjk pf=$pf_title_cjk pf3=$pf3_title_cjk pf2=$pf2_title_cjk}三國 誌", "testing"=>"sw_index_test", "qs"=>"0", "wt"=>"ruby", "rows"=>"25"}}, "response"=>{"numFound"=>193, "start"=>0, "docs"=>[{"id"=>"8303152"}, {"id"=>"6627151"}, {"id"=>"8448620"}, {"id"=>"10156316"}, {"id"=>"10802593"}, {"id"=>"5760057"}, {"id"=>"9146942"}, {"id"=>"6696113"}, {"id"=>"8656623"}, {"id"=>"8656531"}, {"id"=>"5630782"}, {"id"=>"9265099"}, {"id"=>"9407164"}, {"id"=>"9424180"}, {"id"=>"6435388"}, {"id"=>"10102192"}, {"id"=>"6718129"}, {"id"=>"10464035"}, {"id"=>"8656532"}, {"id"=>"6435402"}, {"id"=>"6829978"}, {"id"=>"10721951"}, {"id"=>"4520862"}, {"id"=>"6282759"}, {"id"=>"6624070"}]}}
       Diff:
       @@ -1,14 +1,43 @@
       -[["6696113",
       -  "9265099",
       -  "5630782",
       -  "9424180",
       -  "8656531",
       -  "8656623",
       -  "9407164",
       -  "6718129",
       -  "6435402",
       -  "6829978",
       -  "10102192",
       -  "8656532",
       -  "6435401"]]
       +{"responseHeader"=>
       +  {"status"=>0,
       +   "QTime"=>4,
       +   "params"=>
       +    {"mm"=>"3<86%",
       +     "facet"=>"false",
       +     "fl"=>"id",
       +     "q"=>
       +      "{!qf=$qf_title_cjk pf=$pf_title_cjk pf3=$pf3_title_cjk pf2=$pf2_title_cjk}三國 誌",
       +     "testing"=>"sw_index_test",
       +     "qs"=>"0",
       +     "wt"=>"ruby",
       +     "rows"=>"25"}},
       + "response"=>
       +  {"numFound"=>193,
       +   "start"=>0,
       +   "docs"=>
       +    [{"id"=>"8303152"},
       +     {"id"=>"6627151"},
       +     {"id"=>"8448620"},
       +     {"id"=>"10156316"},
       +     {"id"=>"10802593"},
       +     {"id"=>"5760057"},
       +     {"id"=>"9146942"},
       +     {"id"=>"6696113"},
       +     {"id"=>"8656623"},
       +     {"id"=>"8656531"},
       +     {"id"=>"5630782"},
       +     {"id"=>"9265099"},
       +     {"id"=>"9407164"},
       +     {"id"=>"9424180"},
       +     {"id"=>"6435388"},
       +     {"id"=>"10102192"},
       +     {"id"=>"6718129"},
       +     {"id"=>"10464035"},
       +     {"id"=>"8656532"},
       +     {"id"=>"6435402"},
       +     {"id"=>"6829978"},
       +     {"id"=>"10721951"},
       +     {"id"=>"4520862"},
       +     {"id"=>"6282759"},
       +     {"id"=>"6624070"}]}}
     Shared Example Group: "good results for query" called from ./spec/cjk/chinese_unigram_spec.rb:48
     # ./spec/support/shared_examples_cjk.rb:30:in `block (2 levels) in <top (required)>'

  3) sorting results empty query default sort should be by pub date desc (not in Solr default of document id order)
     Failure/Error: expect((imprint.match(year_regex_str) if imprint) || date.match(year_regex_str)).not_to be_nil, "expected current publication year for #{doc["id"]}"
       expected current publication year for 2334362
     # ./spec/sort_spec.rb:37:in `block in docs_match_current_year'
     # ./spec/sort_spec.rb:34:in `each'
     # ./spec/sort_spec.rb:34:in `docs_match_current_year'
     # ./spec/sort_spec.rb:11:in `block (3 levels) in <top (required)>'
