### PR TITLE
Fixed failures by increasing have_at_most value and replacing deleted catkey with new one

### DIFF
--- a/spec/advanced_search_spec.rb
+++ b/spec/advanced_search_spec.rb
@@ -184,8 +184,8 @@ describe "advanced search" do
       end
       it "title" do
         resp = solr_resp_doc_ids_only({'q'=>"#{title_query('the history man')}"}.merge(solr_args))
-        resp.should have_at_least(1200).results
-        resp.should have_at_most(1300).results
+        resp.should have_at_least(1300).results
+        resp.should have_at_most(1400).results
       end
       it "author and title" do
         resp = solr_resp_doc_ids_only({'q'=>"#{author_query('malcolm bradbury')} AND #{title_query('the history man')}"}.merge(solr_args))

--- a/spec/author_search_spec.rb
+++ b/spec/author_search_spec.rb
@@ -67,7 +67,7 @@ describe "Author Search" do
     resp = solr_resp_doc_ids_only(author_search_args('"Wender, Paul A., "').merge({:rows => 150}))
     resp.should have_at_least(75).documents
     resp.should have_at_most(125).documents
-    paul_h_docs = ["9242084", "781472", "8923874", "7323029", "750072", "7706164"]
+    paul_h_docs = ["9242084", "781472", "10830886", "7323029", "750072", "7706164"]
     paul_h_docs.each { |doc_id| resp.should_not include(doc_id) }
     resp = solr_resp_doc_ids_only(author_search_args '"Wender, Paul H., "')
     resp.should have_at_most(10).documents


### PR DESCRIPTION
1) advanced search author + title author title: history man by malcolm bradbury title
     Failure/Error: resp.should have_at_most(1300).results
       expected at most 1300 results, got 1302
     # ./spec/advanced_search_spec.rb:188:in `block (4 levels) in <top (required)>'

  2) Author Search Wender, Paul A. should not get results for Wender, Paul H
     Failure/Error: resp.should include(paul_h_docs)
       expected {"responseHeader"=>{"status"=>0, "QTime"=>104, "params"=>{"facet"=>"false", "fl"=>"id", "q"=>"{!qf=$qf_author pf=$pf_author pf3=$pf3_author pf2=$pf2_author}\"Wender, Paul H., \"", "testing"=>"sw_index_test", "qt"=>"search", "wt"=>"ruby"}}, "response"=>{"numFound"=>7, "start"=>0, "docs"=>[{"id"=>"9242084"}, {"id"=>"781472"}, {"id"=>"10830886"}, {"id"=>"750072"}, {"id"=>"7323029"}, {"id"=>"10847997"}, {"id"=>"7706164"}]}} to include ["9242084", "781472", "8923874", "7323029", "750072", "7706164"]
       Diff:
       @@ -1,2 +1,23 @@
       -[["9242084", "781472", "8923874", "7323029", "750072", "7706164"]]
       +{"responseHeader"=>
       +  {"status"=>0,
       +   "QTime"=>104,
       +   "params"=>
       +    {"facet"=>"false",
       +     "fl"=>"id",
       +     "q"=>
       +      "{!qf=$qf_author pf=$pf_author pf3=$pf3_author pf2=$pf2_author}\"Wender, Paul H., \"",
       +     "testing"=>"sw_index_test",
       +     "qt"=>"search",
       +     "wt"=>"ruby"}},
       + "response"=>
       +  {"numFound"=>7,
       +   "start"=>0,
       +   "docs"=>
       +    [{"id"=>"9242084"},
       +     {"id"=>"781472"},
       +     {"id"=>"10830886"},
       +     {"id"=>"750072"},
       +     {"id"=>"7323029"},
       +     {"id"=>"10847997"},
       +     {"id"=>"7706164"}]}}
     # ./spec/author_search_spec.rb:74:in `block (2 levels) in <top (required)>'
