### PR TITLE
Fixed failures by increasing have_at_most values

### DIFF
--- a/spec/cjk/japanese_everything_spec.rb
+++ b/spec/cjk/japanese_everything_spec.rb
@@ -54,7 +54,7 @@ describe "Japanese Everything Searches", :japanese => true do
     it_behaves_like "expected result size", 'everything', '地域社会', 490, 575
     it_behaves_like "matches in vern short titles first", 'everything', '地域社会', /^地域社会$/, 1  # exact title match
     context "w lang limit" do
-      it_behaves_like "expected result size", 'everything', '地域社会', 430, 470, lang_limit
+      it_behaves_like "expected result size", 'everything', '地域社会', 450, 500, lang_limit
     end
     context "phrase" do
       it_behaves_like "expected result size", 'everything', '"地域社会"', 266, 300

--- a/spec/default_req_handler_spec.rb
+++ b/spec/default_req_handler_spec.rb
@@ -2,10 +2,10 @@ require 'spec_helper'
 
 describe "Default Request Handler" do
   
-  it "q of 'Buddhism' should get 8,500-10,700 results", :jira => 'VUF-160' do
+  it "q of 'Buddhism' should get 10,400 - 11,400 results", :jira => 'VUF-160' do
     resp = solr_resp_ids_from_query 'Buddhism'
-    resp.should have_at_least(10000).documents
-    resp.should have_at_most(11300).documents
+    resp.should have_at_least(10400).documents
+    resp.should have_at_most(11400).documents
   end
   
   it "q of 'String quartets Parts' and variants should be plausible", :jira => 'VUF-390' do


### PR DESCRIPTION
  1) Japanese Everything Searches (local/regional society) w lang limit behaves like expected result size everything search has between 430 and 470 results
     Failure/Error: resp.should have_at_most(max).results
       expected at most 470 results, got 471
     Shared Example Group: "expected result size" called from ./spec/cjk/japanese_everything_spec.rb:57
     # ./spec/support/shared_examples_cjk.rb:8:in `block (2 levels) in <top (required)>'

  2) Default Request Handler q of 'Buddhism' should get 8,500-10,700 results
     Failure/Error: resp.should have_at_most(11300).documents
       expected at most 11300 documents, got 11303
     # ./spec/default_req_handler_spec.rb:8:in `block (2 levels) in <top (required)>'
