### PR TITLE
Fixed failure by increasing have_at_most value

### DIFF
--- a/spec/advanced_search_spec.rb
+++ b/spec/advanced_search_spec.rb
@@ -336,8 +336,8 @@ describe "advanced search" do
       end
       it "pub info 2010" do
         resp = solr_resp_doc_ids_only({'q'=>"#{pub_info_query('2010')}"}.merge(solr_args))
-        resp.should have_at_least(139000).results
-        resp.should have_at_most(140000).results
+        resp.should have_at_least(139100).results
+        resp.should have_at_most(140100).results
       end
       it "pub info 2011" do
         resp = solr_resp_doc_ids_only({'q'=>"#{pub_info_query('2011')}"}.merge(solr_args))


### PR DESCRIPTION
1) advanced search pub info subject 'soviet union and historiography' and pub info '1910-1911 pub info 2010
     Failure/Error: resp.should have_at_most(140000).results
       expected at most 140000 results, got 140009
     # ./spec/advanced_search_spec.rb:340:in `block (4 levels) in <top (required)>'