### PR TITLE
Added tests for Media Microtext videos and increased have_at_most values

### DIFF
--- a/spec/advanced_search_spec.rb
+++ b/spec/advanced_search_spec.rb
@@ -399,17 +399,36 @@ describe "advanced search" do
       end
       it "before topics selected" do
         resp = solr_resp_doc_ids_only({'fq' => 'format:("Video"), language:("English"), building_facet:("Green")', 'q'=>'collection:*'}.merge(solr_args))
-        resp.should have_at_least(37000).results
-        resp.should have_at_most(38000).results
+        resp.should have_at_least(1000).results
+        resp.should have_at_most(3000).results
       end
       it "add topic feature films" do
         resp = solr_resp_doc_ids_only({'fq' => 'format:("Video"), language:("English"), building_facet:("Green"), topic_facet:("Feature films")', 'q'=>'collection:*'}.merge(solr_args))
-        resp.should have_at_least(18500).results
-        resp.should have_at_most(19500).results
+        resp.should have_at_least(500).results
+        resp.should have_at_most(1000).results
       end
       it "add topic science fiction" do
         resp = solr_resp_doc_ids_only({'fq' => 'format:("Video"), language:("English"), building_facet:("Green"), topic_facet:("Feature films"), topic_facet:("Science fiction films")', 'q'=>'collection:*'}.merge(solr_args))
-        resp.should have_at_least(525).results
+        resp.should have_at_least(40).results
+        resp.should have_at_most(60).results
+      end
+    end
+    context "format video, location Media Microtext, language english" do
+      before(:all) do
+      end
+      it "before topics selected" do
+        resp = solr_resp_doc_ids_only({'fq' => 'format:("Video"), language:("English"), building_facet:("Media & Microtext Center")', 'q'=>'collection:*'}.merge(solr_args))
+        resp.should have_at_least(30000).results
+        resp.should have_at_most(40000).results
+      end
+      it "add topic feature films" do
+        resp = solr_resp_doc_ids_only({'fq' => 'format:("Video"), language:("English"), building_facet:("Media & Microtext Center"), topic_facet:("Feature films")', 'q'=>'collection:*'}.merge(solr_args))
+        resp.should have_at_least(10000).results
+        resp.should have_at_most(20000).results
+      end
+      it "add topic science fiction" do
+        resp = solr_resp_doc_ids_only({'fq' => 'format:("Video"), language:("English"), building_facet:("Media & Microtext Center"), topic_facet:("Feature films"), topic_facet:("Science fiction films")', 'q'=>'collection:*'}.merge(solr_args))
+        resp.should have_at_least(500).results
         resp.should have_at_most(650).results
       end
     end

--- a/spec/cjk/chinese_han_variants_spec.rb
+++ b/spec/cjk/chinese_han_variants_spec.rb
@@ -5,8 +5,8 @@ describe "Chinese Han variants", :chinese => true do
 
   context "Guangxu (pinyin input method vs our data)", :jira => ['VUF-2757', 'VUF-2751'] do
     # The Unicode code point of the "with dot" version (緖) is U+7DD6. And the code point for the "without dot" version (緒) is U+7DD2
-    # In the Unicode standard, it is the "without dot" version (U+7DD2) that is linked to the simplified form (U+7EEA). The "with dot" version is not. 
-    # We have more records with the "with dot" version than the "without dot" version. 
+    # In the Unicode standard, it is the "without dot" version (U+7DD2) that is linked to the simplified form (U+7EEA). The "with dot" version is not.
+    # We have more records with the "with dot" version than the "without dot" version.
     #   added  7DD6 -> 7DD2 mapping
     it_behaves_like "both scripts get expected result size", 'everything', 'with dot', '光緖', 'without dot', '光緒', 5000, 6000
     it_behaves_like "both scripts get expected result size", 'everything', 'traditional (with dot)', '光緖', 'simplified', '光绪', 5000, 6000
@@ -21,9 +21,9 @@ describe "Chinese Han variants", :chinese => true do
       it_behaves_like "expected result size", 'everything', '光绪', 5000, 6000
     end
   end
-  
+
   context "Hiroshi", :jira => 'VUF-2760' do
-    #  廣甯縣 
+    #  廣甯縣
     # desire:  first and second chars 廣寧   become  广宁
     # first char  廣 (U+5EE3) => becomes  广 (U+5E7F)
     # added variant  甯 752F => standard trad 寧 5BE7, which does map to   宁 (U+5B81)
@@ -40,7 +40,7 @@ describe "Chinese Han variants", :chinese => true do
     it_behaves_like "great matches for Hiroshi", trad
     it_behaves_like "great matches for Hiroshi", simp
   end
-  
+
   context "history research" do
     # the 3rd character
     #  历史硏究   硏  U+784F   in the records   6433575, 9336336
@@ -50,7 +50,7 @@ describe "Chinese Han variants", :chinese => true do
       it_behaves_like "matches in vern short titles first", query_type, query, /^歷史(硏|研)究$/, 2
     end
     context "no spaces" do
-      it_behaves_like "both scripts get expected result size", 'title', 'traditional', '歷史研究', 'simplified', '历史研究', 562, 1600
+      it_behaves_like "both scripts get expected result size", 'title', 'traditional', '歷史研究', 'simplified', '历史研究', 562, 1700
       it_behaves_like "great matches for history research", 'title', '歷史研究'
       it_behaves_like "great matches for history research", 'title', '历史研究'
     end
@@ -65,7 +65,7 @@ describe "Chinese Han variants", :chinese => true do
       it_behaves_like "great matches for history research", 'title', '"历史研究"'
     end
   end
-  
+
   context "International Politics Quarterly", :jira => 'VUF-2691' do
     # the fifth character is different:  the traditional character is not xlated to the simple one
     #   correct mapping of 緖 784F (variant) => 研 7814 (std trad)
@@ -77,7 +77,7 @@ describe "Chinese Han variants", :chinese => true do
     it_behaves_like "best matches first", 'title', '國際政治硏究', '7106961', 2
     it_behaves_like "best matches first", 'title', '国际政治研究', '7106961', 2
   end
-  
+
   context "xi ju yan jiu", :jira => 'VUF-2798' do
     # 1st char:   戲 (U+6232)  which can be  戯 (U+622F), 戱 (U+6231) or 戏 (U+620F)
     #  added  戯 6231 (variant) => 戲 6232 (std trad)
@@ -95,7 +95,7 @@ describe "Chinese Han variants", :chinese => true do
     desired_results = ['10160893', '9589465', '9646016']
     qtrad = '嶽州府志'
     qsimp = '岳州府志'
-    it_behaves_like "both scripts get expected result size", 'title', 'traditional', qtrad, 'simplified', qsimp, 3, 10 
+    it_behaves_like "both scripts get expected result size", 'title', 'traditional', qtrad, 'simplified', qsimp, 3, 10
     it_behaves_like "best matches first", 'title', qtrad, desired_results, 6
     it_behaves_like "best matches first", 'title', qsimp, desired_results, 6
   end
@@ -111,17 +111,17 @@ describe "Chinese Han variants", :chinese => true do
   end
 
   context "嶽 5DBD (std trad) => 岳 5CB3 (simp)" do
-    it_behaves_like "both scripts get expected result size", 'title', 'traditional', '富嶽', 'simplified', '富岳', 3, 10 
+    it_behaves_like "both scripts get expected result size", 'title', 'traditional', '富嶽', 'simplified', '富岳', 3, 10
   end
 
   context "囯 56EF (variant) => 國 570B (std trad)" do
-    it_behaves_like "both scripts get expected result size", 'title', 'variant', '国家の', 'std trad', '國家の', 800, 900 
+    it_behaves_like "both scripts get expected result size", 'title', 'variant', '国家の', 'std trad', '國家の', 800, 900
   end
-  
+
   context "戯 6231 (variant) => 戲 6232 (std trad)" do
-    it_behaves_like "both scripts get expected result size", 'everything', 'variant', '戯作文学', 'std trad', '戏作文学', 5, 12 
+    it_behaves_like "both scripts get expected result size", 'everything', 'variant', '戯作文学', 'std trad', '戏作文学', 5, 12
   end
-  
+
   context "敎 654E (variant) => 教 6559 (std trad)" do
     # FIXME:  these do not give the same numbers of results.
     #it_behaves_like "both scripts get expected result size", 'title', 'variant', '敎育', 'std trad', '教育', 3000, 3500, {'fq'=>'language:Japanese'}
@@ -129,7 +129,7 @@ describe "Chinese Han variants", :chinese => true do
     it_behaves_like "expected result size", 'title', '教育', 3000, 3600, {'fq'=>'language:Japanese'}  # std trad
 
   end
-  
+
   context "甯 752F (variant) => 寧 5BE7 (std trad)" do
     it_behaves_like "both scripts get expected result size", 'title', 'variant', '丁甯語の', 'std trad', '丁寧語の', 1, 5
   end

--- a/spec/cjk/chinese_title_spec.rb
+++ b/spec/cjk/chinese_title_spec.rb
@@ -54,7 +54,7 @@ describe "Chinese Title", :chinese => true do
   context "history research", :jira => 'VUF-2771' do
     # see also chinese_han_variants spec, as the 3rd character isn't matching what's in the record
     context "no spaces" do
-      it_behaves_like "both scripts get expected result size", 'title', 'traditional', '歷史研究', 'simplified', '历史研究', 1300, 1600
+      it_behaves_like "both scripts get expected result size", 'title', 'traditional', '歷史研究', 'simplified', '历史研究', 1300, 1700
     end
     context "with space" do
       it_behaves_like "both scripts get expected result size", 'title', 'traditional', '歷史 研究', 'simplified', '历史 研究', 2000, 2500

--- a/spec/synonym_spec.rb
+++ b/spec/synonym_spec.rb
@@ -268,7 +268,7 @@ describe "Tests for synonyms.txt used by Solr SynonymFilterFactory" do
         it "B sharp - title" do
           resp = solr_resp_doc_ids_only(title_search_args('b sharp'))
           resp.should include('8156248').as_first # Geo B. Sharp
-          resp.should have_at_most(850).documents
+          resp.should have_at_most(950).documents
         end
         it "paul f sharp", :fixme => true do
           # from solr logs - doesn't work because it's paul frederic sharp


### PR DESCRIPTION
  1) advanced search facets format video, location green, language english before topics selected
     Failure/Error: resp.should have_at_least(37000).results
       expected at least 37000 results, got 6018
     # ./spec/advanced_search_spec.rb:402:in `block (4 levels) in <top (required)>'

  2) advanced search facets format video, location green, language english add topic feature films
     Failure/Error: resp.should have_at_least(18500).results
       expected at least 18500 results, got 1572
     # ./spec/advanced_search_spec.rb:407:in `block (4 levels) in <top (required)>'

  3) advanced search facets format video, location green, language english add topic science fiction
     Failure/Error: resp.should have_at_least(525).results
       expected at least 525 results, got 42
     # ./spec/advanced_search_spec.rb:412:in `block (4 levels) in <top (required)>'

  4) Chinese Han variants history research no spaces behaves like both scripts get expected result size title search has between 562 and 1600 results
     Failure/Error: resp.should have_at_most(max).results
       expected at most 1600 results, got 1605
     Shared Example Group: "both scripts get expected result size" called from ./spec/cjk/chinese_han_variants_spec.rb:53
     # ./spec/support/shared_examples_cjk.rb:8:in `block (2 levels) in <top (required)>'

  5) Chinese Han variants history research no spaces behaves like both scripts get expected result size title search has between 562 and 1600 results
     Failure/Error: resp.should have_at_most(max).results
       expected at most 1600 results, got 1605
     Shared Example Group: "both scripts get expected result size" called from ./spec/cjk/chinese_han_variants_spec.rb:53
     # ./spec/support/shared_examples_cjk.rb:8:in `block (2 levels) in <top (required)>'

  6) Chinese Title history research no spaces behaves like both scripts get expected result size title search has between 1300 and 1600 results
     Failure/Error: resp.should have_at_most(max).results
       expected at most 1600 results, got 1605
     Shared Example Group: "both scripts get expected result size" called from ./spec/cjk/chinese_title_spec.rb:57
     # ./spec/support/shared_examples_cjk.rb:8:in `block (2 levels) in <top (required)>'

  7) Chinese Title history research no spaces behaves like both scripts get expected result size title search has between 1300 and 1600 results
     Failure/Error: resp.should have_at_most(max).results
       expected at most 1600 results, got 1605
     Shared Example Group: "both scripts get expected result size" called from ./spec/cjk/chinese_title_spec.rb:57
     # ./spec/support/shared_examples_cjk.rb:8:in `block (2 levels) in <top (required)>'

  8) Tests for synonyms.txt used by Solr SynonymFilterFactory musical keys sharp keys should not reduce perceived precision for reasonable non-musical searches with x sharp (space) B sharp - title
     Failure/Error: resp.should have_at_most(850).documents
       expected at most 850 documents, got 861
     # ./spec/synonym_spec.rb:271:in `block (5 levels) in <top (required)>'