### PR TITLE
pins rspec <3.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,4 +4,4 @@ gem 'RedCloth' 		# for textile formatting used in Readme
 gem 'rake'
 gem 'rsolr'       # for sending requests to and getting responses from solr
 gem 'rspec-solr'  # for rspec assertions against solr response object
-gem 'rspec'
+gem 'rspec', '< 3.5'


### PR DESCRIPTION
rspec 3.5 introduced some changes in rspec-expectations private
API that rspec-solr relied on. Working on the updates in rspec-solr
at the moment, but until then we need to pin to an earlier version.

rspec-expectations changes:
https://github.com/rspec/rspec-expectations/blob/93ab745a103472b6fc4c6838a6683f8dbda573c2/lib/rspec/matchers/built_in/include.rb#L89

Reduces failures from:
1962 examples, 411 failures

to:
1962 examples, 66 failures