### PR TITLE
Update rspec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@ config/solr.yml
 rdoc
 doc
 .yardoc
-*.lock
 tmp/
 
 ## vim
@@ -19,4 +18,3 @@ tmtags
 
 ## Rubymine
 .idea/*
-

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,2 @@
+--color
+--require spec_helper

--- a/Gemfile
+++ b/Gemfile
@@ -4,4 +4,4 @@ gem 'RedCloth' 		# for textile formatting used in Readme
 gem 'rake'
 gem 'rsolr'       # for sending requests to and getting responses from solr
 gem 'rspec-solr'  # for rspec assertions against solr response object
-gem 'rspec', '< 3.5'
+gem 'rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,44 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    RedCloth (4.3.2)
+    builder (3.2.3)
+    diff-lcs (1.3)
+    faraday (0.15.2)
+      multipart-post (>= 1.2, < 3)
+    multipart-post (2.0.0)
+    rake (12.3.1)
+    rsolr (2.2.1)
+      builder (>= 2.1.2)
+      faraday (>= 0.9.0)
+    rspec (3.7.0)
+      rspec-core (~> 3.7.0)
+      rspec-expectations (~> 3.7.0)
+      rspec-mocks (~> 3.7.0)
+    rspec-collection_matchers (1.1.3)
+      rspec-expectations (>= 2.99.0.beta1)
+    rspec-core (3.7.1)
+      rspec-support (~> 3.7.0)
+    rspec-expectations (3.7.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.7.0)
+    rspec-mocks (3.7.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.7.0)
+    rspec-solr (3.0.0)
+      rspec (~> 3.5)
+      rspec-collection_matchers
+    rspec-support (3.7.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  RedCloth
+  rake
+  rsolr
+  rspec
+  rspec-solr
+
+BUNDLED WITH
+   1.16.2

--- a/spec/aaa_output_solr_info_spec.rb
+++ b/spec/aaa_output_solr_info_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 # this file is named aaa_blah so it executes first
 describe "Output Solr Information from #{@@solr.uri}" do
   

--- a/spec/advanced_search_spec.rb
+++ b/spec/advanced_search_spec.rb
@@ -1,7 +1,3 @@
-# encoding: utf-8
-
-require 'spec_helper'
-
 describe 'advanced search' do
   context 'title with boolean', jira: 'SW-939' do
     context 'color OR colour photography', jira: 'SW-939' do

--- a/spec/author_search_spec.rb
+++ b/spec/author_search_spec.rb
@@ -1,6 +1,3 @@
-# -*- encoding : utf-8 -*-
-require 'spec_helper'
-
 describe "Author Search" do
 
   context "Corporate author should be included in author search", :jira => 'VUF-633' do

--- a/spec/author_title_spec.rb
+++ b/spec/author_title_spec.rb
@@ -1,6 +1,3 @@
-# -*- encoding : utf-8 -*-
-require 'spec_helper'
-
 describe "Author-Title Search" do
 
   it "Steinbeck Pearl", :jira => 'SW-778' do

--- a/spec/boolean_spec.rb
+++ b/spec/boolean_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe 'boolean operators' do
   # TODO: more better tests for lowercase and?
   context 'default operator:  AND' do

--- a/spec/callnum_search_spec.rb
+++ b/spec/callnum_search_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe "callnum search" do
 
   context "LC" do

--- a/spec/cjk_helper_spec.rb
+++ b/spec/cjk_helper_spec.rb
@@ -1,6 +1,3 @@
-# encoding: utf-8
-require 'spec_helper'
-
 # This spec is for the methods in spec_helper and support/shared_examples_cjk -- it is not a relevancy spec.
 describe "CJK Helper", :chinese => true, :fixme => true do
   

--- a/spec/default_req_handler_spec.rb
+++ b/spec/default_req_handler_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe 'Default Request Handler' do
   it "q of 'Buddhism' should get 12,000 - 13,000 results", jira: 'VUF-160' do
     resp = solr_resp_ids_from_query 'Buddhism'

--- a/spec/diacritic_spec.rb
+++ b/spec/diacritic_spec.rb
@@ -1,6 +1,3 @@
-# -*- encoding : utf-8 -*-
-require 'spec_helper'
-
 describe "Diacritics" do
 
   it "Acute Accent é", :jira => 'VUF-106' do

--- a/spec/dismax_mm_setting_spec.rb
+++ b/spec/dismax_mm_setting_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 #I want to be able to use long multi-word queries
 #In order to get great results which may not contain all the words in my queries
 describe "mm threshold setting for dismax (8 as of 2017/02)" do

--- a/spec/exact_match.rb
+++ b/spec/exact_match.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe "Exact (unstemmed) Match searches" do
   # engineers -engineering (SW-623)
   # humanities NOT human (VUF-1492)

--- a/spec/facets_spec.rb
+++ b/spec/facets_spec.rb
@@ -1,7 +1,3 @@
-# encoding: utf-8
-
-require 'spec_helper'
-
 describe "facet values and queries" do
 
   context "facet queries" do

--- a/spec/full_index_contents_spec.rb
+++ b/spec/full_index_contents_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe "Index Contents" do
 
   shared_examples_for 'collection has all its items' do | coll_val, min_num_exp |

--- a/spec/greek_script_spec.rb
+++ b/spec/greek_script_spec.rb
@@ -1,6 +1,3 @@
-# -*- encoding : utf-8 -*-
-require 'spec_helper'
-
 describe 'Greek script' do
   context 'alpha A α' do
     it 'α in και' do

--- a/spec/journal_title_spec.rb
+++ b/spec/journal_title_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe "journal/newspaper titles" do
 
 # -------   shared example groups --------

--- a/spec/managed_purls_spec.rb
+++ b/spec/managed_purls_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 # collection is indexed, it will be "sirsi" for MARC records, a druid for MODS, and a ckey for MODS with MARC collection records
 # collection_type will only ever be the value "Digital Collection"
 

--- a/spec/non_alpha_chars_spec.rb
+++ b/spec/non_alpha_chars_spec.rb
@@ -1,6 +1,3 @@
-# encoding: utf-8
-require 'spec_helper'
-
 describe "Terms with Numbers or other oddities" do
 
   it "q of 'Two3' should have excellent results", :jira => 'VUF-386', :icu => true do

--- a/spec/number_search_spec.rb
+++ b/spec/number_search_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe "Number as Query String" do
 
   context "ISSN", :jira => 'VUF-169' do

--- a/spec/series_search_spec.rb
+++ b/spec/series_search_spec.rb
@@ -1,7 +1,3 @@
-# encoding: utf-8
-
-require 'spec_helper'
-
 describe "Series Search" do
 
   it "lecture notes in computer science" do

--- a/spec/sort_spec.rb
+++ b/spec/sort_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe 'sorting results' do
   context 'empty query' do
     it 'default sort should be by pub date desc (not in Solr default of document id order)' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require "yaml"
 require 'rsolr'
 

--- a/spec/stemming_spec.rb
+++ b/spec/stemming_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe "Stemming of English words" do
   context "exact matches before stemmed matches" do
     

--- a/spec/stopwords_restored_spec.rb
+++ b/spec/stopwords_restored_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe "Stopwords such as 'the' 'a' 'or' should now work" do
 
   it "A Zukofsky", :jira => 'SW-501' do

--- a/spec/subject_search_spec.rb
+++ b/spec/subject_search_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe 'Subject Search' do
   it 'Quoted individual subjects vs. Quoting the entire subject', jira: 'SW-196' do
     resp = solr_resp_doc_ids_only(subject_search_args '"Older people" "Abuse of"')

--- a/spec/synonym_spec.rb
+++ b/spec/synonym_spec.rb
@@ -1,6 +1,3 @@
-# encoding : utf-8
-require 'spec_helper'
-
 describe "Tests for synonyms.txt used by Solr SynonymFilterFactory" do
 
   context "RDA changes for authority headings", :jira => 'SW-845' do

--- a/spec/title_search_spec.rb
+++ b/spec/title_search_spec.rb
@@ -1,6 +1,3 @@
-# encoding: utf-8
-require 'spec_helper'
-
 describe "Title Search" do
 
   it "780t, 758t included in title search: japanese journal of applied physics", :jira => ['VUF-89', 'SW-441'] do

--- a/spec/vern_scripts_spec.rb
+++ b/spec/vern_scripts_spec.rb
@@ -1,6 +1,3 @@
-# -*- encoding : utf-8 -*-
-require 'spec_helper'
-
 describe "Non-Latin, Non-CJK scripts" do
     
     # TODO:  vernacular with and without diacritics (greek, hebrew, arabic)

--- a/spec/wildcard_spec.rb
+++ b/spec/wildcard_spec.rb
@@ -1,7 +1,3 @@
-# encoding: utf-8
-
-require 'spec_helper'
-
 describe "wildcards in queries" do
   
   context "multi-char wildcard: *" do


### PR DESCRIPTION
Merge #151 first

Closes #149 

This PR does the following:

 - Updates rspec and rspec-solr to modern versions
 - Unignores the `Gemfile.lock` file
 - Adds color and require spec_helper to the `.rspec`

I realize more could be done here, but held back from doing to much at the moment. Improvements could be:
 - rubocop rspec 
 - failing tests -> pending?