### PR TITLE
Address search-result-counting test failures by increasing the window

### DIFF
--- a/spec/advanced_search_spec.rb
+++ b/spec/advanced_search_spec.rb
@@ -73,8 +73,8 @@ describe 'advanced search' do
       end
       it 'keyword chicano' do
         resp = solr_resp_doc_ids_only({ 'q' => 'chicano' }.merge(solr_args))
-        expect(resp.size).to be >= 2700
-        expect(resp.size).to be <= 3400
+        expect(resp.size).to be >= 3500
+        expect(resp.size).to be <= 4100
       end
       # the following is busted due to Solr edismax bug that sets mm=1 if it encounters a OR
       # https://issues.apache.org/jira/browse/SOLR-2649
@@ -134,8 +134,8 @@ describe 'advanced search' do
       it 'keyword' do
         resp = solr_resp_doc_ids_only({ 'q' => 'Socialization' }.merge(solr_args))
         expect(resp).to have_fewer_results_than(solr_resp_ids_from_query('Socialization'))
-        expect(resp.size).to be >= 535_000
-        expect(resp.size).to be <= 575_000
+        expect(resp.size).to be >= 575_000
+        expect(resp.size).to be <= 600_000
       end
       it 'subject (not a phrase) and keyword' do
         resp = solr_resp_doc_ids_only({ 'q' => "#{subject_query('home schooling')} AND Socialization" }.merge(solr_args))
@@ -179,8 +179,8 @@ describe 'advanced search' do
       end
       it 'title' do
         resp = solr_resp_doc_ids_only({ 'q' => "#{title_query('the history man')}" }.merge(solr_args))
-        expect(resp.size).to be >= 1370
-        expect(resp.size).to be <= 1470
+        expect(resp.size).to be >= 1450
+        expect(resp.size).to be <= 1550
       end
       it 'author and title' do
         resp = solr_resp_doc_ids_only({ 'q' => "#{author_query('malcolm bradbury')} AND #{title_query('the history man')}" }.merge(solr_args))
@@ -325,13 +325,13 @@ describe 'advanced search' do
       it "subject without 'and'" do
         resp = solr_resp_doc_ids_only({ 'q' => "#{subject_query('soviet union historiography')}" }.merge(solr_args))
         expect(resp).to have_the_same_number_of_results_as(solr_resp_doc_ids_only(subject_search_args 'soviet union historiography'))
-        expect(resp.size).to be >= 900
-        expect(resp.size).to be <= 1000
+        expect(resp.size).to be >= 950
+        expect(resp.size).to be <= 1050
       end
       it 'pub info 2010' do
         resp = solr_resp_doc_ids_only({ 'q' => "#{pub_info_query('2010')}" }.merge(solr_args))
-        expect(resp.size).to be >= 155_000
-        expect(resp.size).to be <= 165_000
+        expect(resp.size).to be >= 165_000
+        expect(resp.size).to be <= 175_000
       end
       it 'pub info 2011' do
         resp = solr_resp_doc_ids_only({ 'q' => "#{pub_info_query('2011')}" }.merge(solr_args))

--- a/spec/author_search_spec.rb
+++ b/spec/author_search_spec.rb
@@ -64,7 +64,7 @@ describe "Author Search" do
     resp = solr_resp_doc_ids_only(author_search_args('"Wender, Paul A., "').merge({:rows => 150}))
     expect(resp.size).to be >= 85
     expect(resp.size).to be <= 135
-    paul_h_docs = ["9242084", "781472", "10830886", "750072", "7706164", "11839442"]
+    paul_h_docs = ["9242084", "781472", "10830886", "750072", "11839442", "12576610"]
     paul_h_docs.each { |doc_id| expect(resp).not_to include(doc_id) }
     resp = solr_resp_doc_ids_only(author_search_args '"Wender, Paul H., "')
     expect(resp.size).to be <= 10

--- a/spec/author_title_spec.rb
+++ b/spec/author_title_spec.rb
@@ -12,8 +12,8 @@ describe "Author-Title Search" do
   it "Beethoven violin concerto", :jira => 'SW-778' do
     q = '"Beethoven, Ludwig van, 1770-1827. Concertos, violin, orchestra, op. 61, D major"'
     resp = solr_response(author_title_search_args(q).merge!({'fl'=>'id,author_person_display', 'facet'=>false}))
-    expect(resp.size).to be >= 270
-    expect(resp.size).to be <= 300
+    expect(resp.size).to be >= 295
+    expect(resp.size).to be <= 325
     expect(resp).to include("author_person_display" => /Beethoven/i).in_each_of_first(5).documents
     expect(resp).not_to include("author_person_display" => /Stowell/i).in_each_of_first(20).documents
   end

--- a/spec/boolean_spec.rb
+++ b/spec/boolean_spec.rb
@@ -75,7 +75,7 @@ describe 'boolean operators' do
       end
       it 'history man' do
         resp = solr_resp_ids_from_query 'history man'
-        expect(resp).to include('1433520').in_first(3)
+        expect(resp).to include('1433520').in_first(5)
       end
     end
 

--- a/spec/boolean_spec.rb
+++ b/spec/boolean_spec.rb
@@ -286,8 +286,8 @@ describe 'boolean operators' do
     context 'nested OR within NOT as subject', jira: 'VUF-1387' do
       it 'digestive organs' do
         resp = solr_resp_doc_ids_only(subject_search_args 'digestive organs')
-        expect(resp.size).to be >= 590
-        expect(resp.size).to be <= 620
+        expect(resp.size).to be >= 600
+        expect(resp.size).to be <= 650
       end
       it 'digestive organs NOT disease', pending: 'fixme' do
         # the following is busted due to Solr edismax bug that sets mm=1 if it encounters a NOT

--- a/spec/cjk/chinese_everything_spec.rb
+++ b/spec/cjk/chinese_everything_spec.rb
@@ -16,7 +16,7 @@ describe 'Chinese Everything', chinese: true do
   context 'contemporary china economic study', jira: 'VUF-2767' do
     trad = '當代中國經濟研究'
     simp = '当代中国经济研究'
-    it_behaves_like 'both scripts get expected result size', 'everything', 'traditional', trad, 'simplified', simp, 12, 170
+    it_behaves_like 'both scripts get expected result size', 'everything', 'traditional', trad, 'simplified', simp, 12, 190
     it_behaves_like 'best matches first', 'everything', simp, '4188269', 4
     it_behaves_like 'best matches first', 'everything', simp,
                     %w(4164852 4188269 10153644 8225832 4335450 4185340
@@ -44,10 +44,10 @@ describe 'Chinese Everything', chinese: true do
 
   context 'history research', jira: 'VUF-2771' do
     context 'no spaces' do
-      it_behaves_like 'both scripts get expected result size', 'everything', 'traditional', '歷史研究', 'simplified', '历史研究', 7300, 7600
+      it_behaves_like 'both scripts get expected result size', 'everything', 'traditional', '歷史研究', 'simplified', '历史研究', 7400, 7700
     end
     context 'with space' do
-      it_behaves_like 'both scripts get expected result size', 'everything', 'traditional', '歷史研究', 'simplified', '历史研究', 7300, 7600
+      it_behaves_like 'both scripts get expected result size', 'everything', 'traditional', '歷史研究', 'simplified', '历史研究', 7400, 7700
     end
     context 'as phrase' do
       it_behaves_like 'both scripts get expected result size', 'everything', 'traditional', '"歷史研究"', 'simplified', '"历史研究"', 600, 900
@@ -55,10 +55,10 @@ describe 'Chinese Everything', chinese: true do
   end
 
   context 'Nanyang or Nanʼyō', jira: 'SW-100' do
-    it_behaves_like 'result size and vern short title matches first', 'everything', '南洋', 750, 850, /南洋/, 100
+    it_behaves_like 'result size and vern short title matches first', 'everything', '南洋', 775, 875, /南洋/, 100
     it_behaves_like 'matches in vern titles', 'everything', '南洋', /南洋群島/, 20
     # Nan'yō Guntō
-    it_behaves_like 'result size and vern short title matches first', 'everything', '南洋群島', 50, 60, /南洋群島/, 15
+    it_behaves_like 'result size and vern short title matches first', 'everything', '南洋群島', 55, 65, /南洋群島/, 15
     it_behaves_like 'good results for query', 'everything', '椰風蕉雨話南洋', 1, 1, '5564542', 1
   end
 

--- a/spec/cjk/chinese_han_variants_spec.rb
+++ b/spec/cjk/chinese_han_variants_spec.rb
@@ -49,7 +49,7 @@ describe 'Chinese Han variants', chinese: true do
       it_behaves_like 'matches in vern short titles first', query_type, query, /^歷史(硏|研)究$/, 2
     end
     context 'no spaces' do
-      it_behaves_like 'both scripts get expected result size', 'title', 'traditional', '歷史研究', 'simplified', '历史研究', 700, 1850
+      it_behaves_like 'both scripts get expected result size', 'title', 'traditional', '歷史研究', 'simplified', '历史研究', 750, 1900
       it_behaves_like 'great matches for history research', 'title', '歷史研究'
       it_behaves_like 'great matches for history research', 'title', '历史研究'
     end

--- a/spec/cjk/chinese_title_spec.rb
+++ b/spec/cjk/chinese_title_spec.rb
@@ -54,13 +54,13 @@ describe "Chinese Title", :chinese => true do
   context "history research", :jira => 'VUF-2771' do
     # see also chinese_han_variants spec, as the 3rd character isn't matching what's in the record
     context "no spaces" do
-      it_behaves_like "both scripts get expected result size", 'title', 'traditional', '歷史研究', 'simplified', '历史研究', 1300, 1850
+      it_behaves_like "both scripts get expected result size", 'title', 'traditional', '歷史研究', 'simplified', '历史研究', 1350, 1900
     end
     context "with space" do
       it_behaves_like "both scripts get expected result size", 'title', 'traditional', '歷史 研究', 'simplified', '历史 研究', 2000, 2500
     end
     context "as phrase" do
-      it_behaves_like "both scripts get expected result size", 'title', 'traditional', '"歷史研究"', 'simplified', '"历史研究"', 250, 325
+      it_behaves_like "both scripts get expected result size", 'title', 'traditional', '"歷史研究"', 'simplified', '"历史研究"', 275, 350
     end
   end
 
@@ -134,12 +134,12 @@ describe "Chinese Title", :chinese => true do
       it_behaves_like "matches in vern short titles first", 'title', query, /^全宋(筆|笔)(記|记)[^[[:alpha:]]]*$/, 5
     end
     context "no spaces" do
-      it_behaves_like "both scripts get expected result size", 'title', 'traditional', '全宋笔记', 'simplified', '全宋筆記', 6, 8
+      it_behaves_like "both scripts get expected result size", 'title', 'traditional', '全宋笔记', 'simplified', '全宋筆記', 8, 10
       it_behaves_like "great results for Quan Song bi ji", '全宋笔记'
       it_behaves_like "great results for Quan Song bi ji", '全宋筆記'
     end
     context "middle space" do
-      it_behaves_like "both scripts get expected result size", 'title', 'traditional', '全宋 笔记', 'simplified', '全宋 筆記', 6, 8
+      it_behaves_like "both scripts get expected result size", 'title', 'traditional', '全宋 笔记', 'simplified', '全宋 筆記', 8, 10
       it_behaves_like "great results for Quan Song bi ji", '全宋 笔记'
       it_behaves_like "great results for Quan Song bi ji", '全宋 筆記'
     end
@@ -159,7 +159,7 @@ describe "Chinese Title", :chinese => true do
       it_behaves_like "matches in vern short titles first", 'title', query, /^三(國|国|囯)演(義|义)[^[[:alpha:]]]*$/, 13
     end
     context "no spaces" do
-      it_behaves_like "both scripts get expected result size", 'title', 'traditional', '三國演義', 'simplified', '三国演义', 90, 100
+      it_behaves_like "both scripts get expected result size", 'title', 'traditional', '三國演義', 'simplified', '三国演义', 95, 105
       it_behaves_like "great results for Three Kingdoms", '三國演義'
       it_behaves_like "great results for Three Kingdoms", '三国演义'
     end

--- a/spec/cjk/chinese_unigram_spec.rb
+++ b/spec/cjk/chinese_unigram_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 
 describe 'Chinese Unigrams', chinese: true do
   context 'Gone with the Wind', jira: 'VUF-2789' do
-    it_behaves_like 'result size and vern short title matches first', 'title', '飘', 120, 150, /(飘|飄)/, 2
+    it_behaves_like 'result size and vern short title matches first', 'title', '飘', 145, 175, /(飘|飄)/, 2
     it_behaves_like 'best matches first', 'title', '飘', '6701323', 5 # book
     it_behaves_like 'best matches first', 'title', '飘', '7737681', 5 # video
   end
@@ -14,8 +14,8 @@ describe 'Chinese Unigrams', chinese: true do
   end
 
   context 'Zen', jira: 'VUF-2790' do
-    it_behaves_like 'result size and vern short title matches first', 'title', '禪', 900, 1275, /(禪|禅)/, 50
-    it_behaves_like 'both scripts get expected result size', 'title', 'traditional', '禪', 'simplified', '禅', 900, 1275
+    it_behaves_like 'result size and vern short title matches first', 'title', '禪', 925, 1300, /(禪|禅)/, 50
+    it_behaves_like 'both scripts get expected result size', 'title', 'traditional', '禪', 'simplified', '禅', 925, 1300
     it_behaves_like 'best matches first', 'title', '禪', '6815304', 10
   end
 

--- a/spec/cjk/japanese_everything_spec.rb
+++ b/spec/cjk/japanese_everything_spec.rb
@@ -39,7 +39,7 @@ describe 'Japanese Everything Searches', japanese: true do
   end
 
   context 'Japan China thought', jira: 'VUF-2737' do
-    it_behaves_like 'expected result size', 'everything', '日本  中国  思想', 65, 100
+    it_behaves_like 'expected result size', 'everything', '日本  中国  思想', 80, 125
     context 'w lang limit' do
       it_behaves_like 'expected result size', 'everything', '日本  中国  思想', 32, 40, lang_limit
     end
@@ -118,7 +118,7 @@ describe 'Japanese Everything Searches', japanese: true do
   context 'TPP', jira: 'VUF-2694' do
     it_behaves_like 'result size and vern short title matches first', 'everything', 'TPP', 125, 225, /TPP/, 6
     context 'w lang limit' do
-      it_behaves_like 'result size and vern short title matches first', 'everything', 'TPP', 25, 50, /TPP/, 6, lang_limit
+      it_behaves_like 'result size and vern short title matches first', 'everything', 'TPP', 50, 75, /TPP/, 6, lang_limit
     end
   end
 end

--- a/spec/cjk/japanese_han_variants_spec.rb
+++ b/spec/cjk/japanese_han_variants_spec.rb
@@ -17,9 +17,9 @@ describe 'Japanese Kanji variants', japanese: true do
       it_behaves_like 'matches in vern short titles first', 'title', '仏教', /^(佛|仏)(教|敎).*$/, 7 # title starts w match
       context 'w lang limit' do
         # trad
-        it_behaves_like 'result size and vern short title matches first', 'everything', '佛教', 1300, 1700, /(佛|仏)(教|敎)/, 100, lang_limit
+        it_behaves_like 'result size and vern short title matches first', 'everything', '佛教', 1325, 1725, /(佛|仏)(教|敎)/, 100, lang_limit
         # modern
-        it_behaves_like 'result size and vern short title matches first', 'everything', '仏教', 1300, 1700, /(佛|仏)(教|敎)/, 100, lang_limit
+        it_behaves_like 'result size and vern short title matches first', 'everything', '仏教', 1325, 1725, /(佛|仏)(教|敎)/, 100, lang_limit
       end
     end # buddhism
 
@@ -33,8 +33,8 @@ describe 'Japanese Kanji variants', japanese: true do
       # Second char of traditional doesn't translate to second char of modern with ICU traditional->simplified
       # FIXME:  these do not give the same numbers of results.
       # it_behaves_like "both scripts get expected result size", 'everything', 'traditional', '江戶', 'modern', '江戸', 1900, 2000
-      it_behaves_like 'expected result size', 'everything', '江戶', 2100, 2250  # trad
-      it_behaves_like 'expected result size', 'everything', '江戸', 2100, 2250  # modern
+      it_behaves_like 'expected result size', 'everything', '江戶', 2150, 2300  # trad
+      it_behaves_like 'expected result size', 'everything', '江戸', 2150, 2300  # modern
 
       it_behaves_like 'matches in vern short titles first', 'everything', '江戶', /(江戶|江戸)/, 100  # trad
       it_behaves_like 'matches in vern short titles first', 'everything', '江戸', /(江戶|江戸)/, 100  # modern
@@ -65,8 +65,8 @@ describe 'Japanese Kanji variants', japanese: true do
       # "慶応義塾大学(Keio Gijuku University)" + "Search everything" retrieves 146 hits (all relevant). "慶應義塾大学" retrieves 262 hits (all relevant).
       # FIXME:  these do not give the same numbers of results.  Even with lang_limit.  But they are both analyzed to the same char string  2013-10-14
       #      it_behaves_like "both scripts get expected result size", 'everything', 'traditional', '慶應義塾大学', 'modern', '慶応義塾大学', 375, 450
-      it_behaves_like 'expected result size', 'everything', '慶應義塾大学', 375, 550  # trad
-      it_behaves_like 'expected result size', 'everything', '慶応義塾大学', 375, 550 # modern
+      it_behaves_like 'expected result size', 'everything', '慶應義塾大学', 400, 575  # trad
+      it_behaves_like 'expected result size', 'everything', '慶応義塾大学', 400, 575 # modern
     end
 
     context 'Mahayana Buddhism', jira: 'VUF-2761' do

--- a/spec/cjk/japanese_title_spec.rb
+++ b/spec/cjk/japanese_title_spec.rb
@@ -116,7 +116,7 @@ describe 'Japanese Title searches', japanese: true do
   context 'Study of Buddhism', jira: ['VUF-2732', 'VUF-2733'] do
     # First char of traditional doesn't translate to first char of modern with ICU traditional->simplified
     # (see also japanese han variants for plain buddhism)
-    it_behaves_like 'both scripts get expected result size', 'title', 'traditional', '佛教學', 'modern', '仏教学', 350, 650
+    it_behaves_like 'both scripts get expected result size', 'title', 'traditional', '佛教學', 'modern', '仏教学', 375, 675
     it_behaves_like 'both scripts get expected result size', 'title', 'traditional', '佛教學', 'modern', '仏教学', 200, 300, lang_limit
     it_behaves_like 'matches in vern short titles first', 'title', '佛教學', /(佛|仏)(教|敎)(學|学)/, 15, lang_limit # trad
     it_behaves_like 'matches in vern short titles first', 'title', '仏教学', /(佛|仏)(教|敎)(學|学)/, 15, lang_limit # modern
@@ -130,7 +130,7 @@ describe 'Japanese Title searches', japanese: true do
   context 'survey/investigation', jira: 'VUF-2727' do
     # second trad char isn't translated to modern with ICU trad -> simp
     # (see also japanese han variants)
-    it_behaves_like 'both scripts get expected result size', 'title', 'traditional', ' 調查', 'modern', '調査', 8050, 9050
+    it_behaves_like 'both scripts get expected result size', 'title', 'traditional', ' 調查', 'modern', '調査', 8075, 9075
     # exact title match
     it_behaves_like 'matches in vern short titles first', 'title', '調查', /^(調查|調査)[^[[:alnum:]]]*$/, 1 # trad
     it_behaves_like 'matches in vern short titles first', 'title', '調査', /^(調查|調査)[^[[:alnum:]]]*$/, 1 # mod

--- a/spec/cjk/korean_author_spec.rb
+++ b/spec/cjk/korean_author_spec.rb
@@ -31,7 +31,7 @@ describe "Korean author", :korean => true do
                   '9588786',  # has 3 chars jumbled in 710:  경희 대학교. 밝은 사회 연구소
                   ]
     shared_examples_for "good author results for 은희경" do | query |
-      it_behaves_like 'good results for query', 'author', query, 15, 30, relevant, 20
+      it_behaves_like 'good results for query', 'author', query, 20, 35, relevant, 20
       it_behaves_like 'does not find irrelevant results', 'author', query, irrelevant
     end
     context "은희경 (no spaces)" do

--- a/spec/cjk/korean_spacing_spec.rb
+++ b/spec/cjk/korean_spacing_spec.rb
@@ -122,7 +122,8 @@ describe "Korean spacing", :korean => true do
     context "강물이 될때 까지 (space between  이 and 될,  때 and 까)" do
       it_behaves_like "good results for 강물이될때까지", '강물이 될때 까지'
     end
-    context "강물 이 될 때 까지 (as in the record)", pending: 'includes newly cataloged catkey 12437806' do
+    context "강물 이 될 때 까지 (as in the record)", fixme: true do
+      # per Korean cataloger, the results should not include ckey 12437806.
       it_behaves_like "good results for 강물이될때까지", '강물 이 될 때 까지'
     end
   end # until the river  VUF-2744

--- a/spec/cjk/korean_spacing_spec.rb
+++ b/spec/cjk/korean_spacing_spec.rb
@@ -122,7 +122,7 @@ describe "Korean spacing", :korean => true do
     context "강물이 될때 까지 (space between  이 and 될,  때 and 까)" do
       it_behaves_like "good results for 강물이될때까지", '강물이 될때 까지'
     end
-    context "강물 이 될 때 까지 (as in the record)" do
+    context "강물 이 될 때 까지 (as in the record)", pending: 'includes newly cataloged catkey 12437806' do
       it_behaves_like "good results for 강물이될때까지", '강물 이 될 때 까지'
     end
   end # until the river  VUF-2744
@@ -150,7 +150,7 @@ describe "Korean spacing", :korean => true do
 
   context "Korean economy" do
     shared_examples_for "good results for 한국경제" do | query |
-      it_behaves_like "expected result size", 'everything', query, 850, 1050
+      it_behaves_like "expected result size", 'everything', query, 850, 1150
       # no spaces, exact 245a
       it_behaves_like 'best matches first', 'everything', query, '6812133', 7
       # spaces, exact 245a
@@ -285,7 +285,7 @@ describe "Korean spacing", :korean => true do
   end # Contemporary North Korean literature
   context "Art History of the Choson dynasty" do
     shared_examples_for "good results for 조선미술사" do | query |
-      it_behaves_like "good results for query", 'everything', query, 15, 35, '7676909', 1
+      it_behaves_like "good results for query", 'everything', query, 20, 40, '7676909', 1
     end
     context "조선미술사 (normal spacing)" do
       it_behaves_like "good results for 조선미술사", '조선미술사'
@@ -297,7 +297,7 @@ describe "Korean spacing", :korean => true do
 
   context "History of South Korea" do
     shared_examples_for "good results for 한국의 역사" do | query |
-      it_behaves_like "expected result size", 'everything', query, 550, 800
+      it_behaves_like "expected result size", 'everything', query, 600, 850
     end
     context "한국의 역사 (normal spacing)" do
       it_behaves_like "good results for 한국의 역사", '한국의 역사'
@@ -309,7 +309,7 @@ describe "Korean spacing", :korean => true do
 
   context "Experience and the type of novel" do
     shared_examples_for "good results for 경험과 소설의 형식" do | query |
-      it_behaves_like "good results for query", 'everything', query, 1, 10, '7875464', 1
+      it_behaves_like "good results for query", 'everything', query, 1, 15, '7875464', 1
     end
     context "경험과 소설의 형식 (normal spacing)" do
       it_behaves_like "good results for 경험과 소설의 형식", '경험과 소설의 형식'
@@ -355,7 +355,7 @@ describe "Korean spacing", :korean => true do
     end
     context "Right to speak in the Choson dynasty period" do
       shared_examples_for "good results for 鮮時代의 言權" do | query |
-        it_behaves_like "good results for query", 'everything', query, 1, 40, '6633303', 1
+        it_behaves_like "good results for query", 'everything', query, 1, 50, '6633303', 1
       end
       context "鮮時代의 言權 (normal spacing)" do
         it_behaves_like "good results for 鮮時代의 言權", '鮮時代의 言權'

--- a/spec/cjk/korean_unigram_spec.rb
+++ b/spec/cjk/korean_unigram_spec.rb
@@ -5,7 +5,7 @@ describe "Korean: Unigram Searches", :korean => true do
   # from email from Vitus, Aug 20, 2012
 
   context "title  창 (window)" do
-    it_behaves_like "expected result size", 'title', '창', 825, 1025
+    it_behaves_like "expected result size", 'title', '창', 825, 1050
     before(:all) do
       @resp = solr_response({'q'=>cjk_q_arg('title', '창'), 'fl'=>'id,vern_title_245a_display', 'facet'=>false} )
     end

--- a/spec/default_req_handler_spec.rb
+++ b/spec/default_req_handler_spec.rb
@@ -1,8 +1,8 @@
 describe 'Default Request Handler' do
   it "q of 'Buddhism' should get 12,000 - 13,000 results", jira: 'VUF-160' do
     resp = solr_resp_ids_from_query 'Buddhism'
-    expect(resp.size).to be >= 12_750
-    expect(resp.size).to be <= 13_750
+    expect(resp.size).to be >= 13_750
+    expect(resp.size).to be <= 14_750
   end
 
   it "q of 'String quartets Parts' and variants should be plausible", jira: 'VUF-390' do
@@ -155,7 +155,7 @@ describe 'Default Request Handler' do
     it 'humanities 21st century america english' do
       # 70
       resp = solr_resp_ids_from_query('humanities 21st century america english')
-      expect(resp.size).to be <= 60
+      expect(resp.size).to be <= 70
     end
   end
 

--- a/spec/facets_spec.rb
+++ b/spec/facets_spec.rb
@@ -119,8 +119,8 @@ describe "facet values and queries" do
     end
     it 'Thesis/Dissertation|Doctoral results' do
       resp = solr_resp_doc_ids_only({'fq'=>['stanford_work_facet_hsim:"Thesis/Dissertation|Doctoral"']})
-      expect(resp.size).to be >= 37_600
-      expect(resp.size).to be <= 38_600
+      expect(resp.size).to be >= 38_000
+      expect(resp.size).to be <= 39_000
     end
     it 'Other student work results' do
       resp = solr_resp_doc_ids_only({'fq'=>['stanford_work_facet_hsim:"Other student work"']})

--- a/spec/facets_spec.rb
+++ b/spec/facets_spec.rb
@@ -114,8 +114,8 @@ describe "facet values and queries" do
     end
     it 'Thesis/Dissertation|Master\'s results' do
       resp = solr_resp_doc_ids_only({'fq'=>['stanford_work_facet_hsim:"Thesis/Dissertation|Master\'s"']})
-      expect(resp.size).to be >= 14_100
-      expect(resp.size).to be <= 15_100
+      expect(resp.size).to be >= 13_200
+      expect(resp.size).to be <= 14_200
     end
     it 'Thesis/Dissertation|Doctoral results' do
       resp = solr_resp_doc_ids_only({'fq'=>['stanford_work_facet_hsim:"Thesis/Dissertation|Doctoral"']})

--- a/spec/facets_spec.rb
+++ b/spec/facets_spec.rb
@@ -119,8 +119,8 @@ describe "facet values and queries" do
     end
     it 'Thesis/Dissertation|Doctoral results' do
       resp = solr_resp_doc_ids_only({'fq'=>['stanford_work_facet_hsim:"Thesis/Dissertation|Doctoral"']})
-      expect(resp.size).to be >= 36_600
-      expect(resp.size).to be <= 37_600
+      expect(resp.size).to be >= 37_600
+      expect(resp.size).to be <= 38_600
     end
     it 'Other student work results' do
       resp = solr_resp_doc_ids_only({'fq'=>['stanford_work_facet_hsim:"Other student work"']})

--- a/spec/journal_title_spec.rb
+++ b/spec/journal_title_spec.rb
@@ -608,7 +608,7 @@ describe "journal/newspaper titles" do
 
     it "as title search with format journal" do
       resp = solr_response(title_search_args('nature').merge({'fq' => 'format_main_ssim:"Journal/Periodical"', 'fl'=>'id,title_display', 'facet'=>false}))
-      expect(resp.size).to be <= 1750
+      expect(resp.size).to be <= 1775
       expect(resp).to include({'title_display' => /^Nature/}).in_first(5)
       expect(resp).to include({'title_display' => /^Nature; international journal of science/}).in_first(5)
     end

--- a/spec/number_search_spec.rb
+++ b/spec/number_search_spec.rb
@@ -16,8 +16,8 @@ describe "Number as Query String" do
     end
 
     it "'The Times' ISSN 0140-0460 should get great results with or without hyphen", :icu => true do
-      expect(solr_resp_ids_from_query('0140-0460')).to include(['425948', '425951']).in_first(5)
-      expect(solr_resp_ids_from_query('01400460')).to include(['425948', '425951']).in_first(5)
+      expect(solr_resp_ids_from_query('0140-0460')).to include(['425948', '425951']).in_first(7)
+      expect(solr_resp_ids_from_query('01400460')).to include(['425948', '425951']).in_first(7)
     end
 
     context "with X as last char" do

--- a/spec/punctuation/hyphen_spec.rb
+++ b/spec/punctuation/hyphen_spec.rb
@@ -221,9 +221,9 @@ describe "hyphen in queries" do
   end
 
   context "'customer-driven academic library'", :jira => ['SW-388', 'VUF-846'] do
-    it_behaves_like "hyphens without spaces imply phrase", "customer-driven academic library", "12582003", 1
-    it_behaves_like "hyphens ignored", "customer- driven academic library", "12582003", 1
-    it_behaves_like "hyphens with space before but not after are treated as NOT, but ignored in phrase", "customer -driven academic library", nil, "12582003"
+    it_behaves_like "hyphens without spaces imply phrase", "customer-driven academic library", "7778647", 3
+    it_behaves_like "hyphens ignored", "customer- driven academic library", "7778647", 3
+    it_behaves_like "hyphens with space before but not after are treated as NOT, but ignored in phrase", "customer -driven academic library", nil, "7778647"
 #   hyphens with both spaces don't work right
 #    it_behaves_like "hyphens ignored", "customer - driven academic library", "7778647", 1
   end
@@ -295,8 +295,8 @@ describe "hyphen in queries" do
   end
 
   context "'Silence : a thirteenth-century French romance'" do
-    it_behaves_like "hyphens without spaces imply phrase", "Silence : a thirteenth-century French romance", "12626562", 1
-    it_behaves_like "hyphens ignored", "Silence : a thirteenth- century French romance", "12626562", 1
+    it_behaves_like "hyphens without spaces imply phrase", "Silence : a thirteenth-century French romance", "2416395", 2
+    it_behaves_like "hyphens ignored", "Silence : a thirteenth- century French romance", "2416395", 2
     # the following is busted due to Solr edismax bug
     # https://issues.apache.org/jira/browse/SOLR-2649
 #    it_behaves_like "hyphens with space before but not after are treated as NOT, but ignored in phrase", "Silence : a thirteenth -century French romance", nil, "11484079"

--- a/spec/punctuation/hyphen_spec.rb
+++ b/spec/punctuation/hyphen_spec.rb
@@ -221,9 +221,9 @@ describe "hyphen in queries" do
   end
 
   context "'customer-driven academic library'", :jira => ['SW-388', 'VUF-846'] do
-    it_behaves_like "hyphens without spaces imply phrase", "customer-driven academic library", "7778647", 1
-    it_behaves_like "hyphens ignored", "customer- driven academic library", "7778647", 1
-    it_behaves_like "hyphens with space before but not after are treated as NOT, but ignored in phrase", "customer -driven academic library", nil, "7778647"
+    it_behaves_like "hyphens without spaces imply phrase", "customer-driven academic library", "12582003", 1
+    it_behaves_like "hyphens ignored", "customer- driven academic library", "12582003", 1
+    it_behaves_like "hyphens with space before but not after are treated as NOT, but ignored in phrase", "customer -driven academic library", nil, "12582003"
 #   hyphens with both spaces don't work right
 #    it_behaves_like "hyphens ignored", "customer - driven academic library", "7778647", 1
   end
@@ -295,8 +295,8 @@ describe "hyphen in queries" do
   end
 
   context "'Silence : a thirteenth-century French romance'" do
-    it_behaves_like "hyphens without spaces imply phrase", "Silence : a thirteenth-century French romance", "11484079", 1
-    it_behaves_like "hyphens ignored", "Silence : a thirteenth- century French romance", "11484079", 1
+    it_behaves_like "hyphens without spaces imply phrase", "Silence : a thirteenth-century French romance", "12626562", 1
+    it_behaves_like "hyphens ignored", "Silence : a thirteenth- century French romance", "12626562", 1
     # the following is busted due to Solr edismax bug
     # https://issues.apache.org/jira/browse/SOLR-2649
 #    it_behaves_like "hyphens with space before but not after are treated as NOT, but ignored in phrase", "Silence : a thirteenth -century French romance", nil, "11484079"

--- a/spec/series_search_spec.rb
+++ b/spec/series_search_spec.rb
@@ -127,7 +127,7 @@ describe "Series Search" do
     it "everything search, phrase" do
       resp = solr_resp_ids_from_query  '"Studies in Modern Poetry"'
       expect(resp.size).to be >= 15
-      expect(resp).to include(['5709847', '4075051', '3865171', '10338326', '7146913'])
+      expect(resp).to include(['5709847', '4075051', '3865171', '10727485', '588517'])
     end
   end
 

--- a/spec/series_search_spec.rb
+++ b/spec/series_search_spec.rb
@@ -2,14 +2,14 @@ describe "Series Search" do
 
   it "lecture notes in computer science" do
     resp = solr_resp_doc_ids_only(series_search_args 'lecture notes in computer science')
-    expect(resp.size).to be >= 9450
-    expect(resp.size).to be <= 9700
+    expect(resp.size).to be >= 11000
+    expect(resp.size).to be <= 12000
   end
 
   it "Lecture notes in statistics (Springer-Verlag)", :jira => 'VUF-1221' do
     resp = solr_resp_doc_ids_only(series_search_args 'Lecture notes in statistics (Springer-Verlag)')
-    expect(resp.size).to be >= 175
-    expect(resp.size).to be <= 300
+    expect(resp.size).to be >= 300
+    expect(resp.size).to be <= 325
   end
 
   it "Japanese journal of applied physics" do

--- a/spec/sort_spec.rb
+++ b/spec/sort_spec.rb
@@ -13,7 +13,7 @@ describe 'sorting results' do
       #      resp = solr_response({'fq'=>'format:Book', 'fl'=>'id,pub_date', 'facet'=>false})
       #      year = Time.new.year
       #      resp.should include("pub_date" => /(#{year}|#{year + 1}|#{year + 2})/).in_each_of_first(20).documents
-      resp = solr_response('fq' => 'format_main_ssim:Book', 'fl' => 'id,pub_date,imprint_display,title_245a_display', 'facet' => false, 'rows' => 1500)
+      resp = solr_response('fq' => 'format_main_ssim:Book', 'fl' => 'id,pub_date,imprint_display,title_245a_display', 'facet' => false, 'rows' => 5000)
       docs_match_current_year resp
       # 12283692: _Gendered lives_ (pub_date (008) as 2019)
       # before 12283105: _Brain & behavior_ (pub_date (008) as 2018)

--- a/spec/stemming_spec.rb
+++ b/spec/stemming_spec.rb
@@ -115,7 +115,7 @@ describe "Stemming of English words" do
       expect(resp).to have_the_same_number_of_results_as(solr_resp_doc_ids_only(title_search_args 'knight'))
     end
     it "deeply should stem to same as deep" do
-      resp = solr_resp_ids_full_titles(title_search_args('deeply').merge({:rows => '200'}))
+      resp = solr_resp_ids_full_titles(title_search_args('deeply').merge({:rows => '500'}))
       expect(resp).to include('title_full_display' => /deep /i)
       # not sure why this isn't true
       # resp.should have_the_same_number_of_results_as(solr_resp_doc_ids_only(title_search_args 'deep'))
@@ -196,7 +196,6 @@ describe "Stemming of English words" do
   end
 
   context "collisions" do
-
     # Also:
     # populate <--> population but not populus
     # compute = computes = computer = computing  computation = computational

--- a/spec/subject_search_spec.rb
+++ b/spec/subject_search_spec.rb
@@ -24,8 +24,8 @@ describe 'Subject Search' do
     it 'not as phrase' do
       # not a heading, but a combo of words from 3 diff headings
       resp = solr_resp_doc_ids_only(subject_search_args('China women history').merge(fq: 'language:English'))
-      expect(resp.size).to be >= 170
-      expect(resp.size).to be <= 250
+      expect(resp.size).to be >= 230
+      expect(resp.size).to be <= 300
     end
     it 'as phrase' do
       resp = solr_resp_doc_ids_only(subject_search_args '"China women history"')
@@ -51,8 +51,8 @@ describe 'Subject Search' do
 
   it 'Rock music 1951-1960', jira: 'VUF-388' do
     resp = solr_resp_doc_ids_only(subject_search_args 'Rock music 1951-1960')
-    expect(resp.size).to be >= 30
-    expect(resp.size).to be <= 40
+    expect(resp.size).to be >= 35
+    expect(resp.size).to be <= 45
   end
 
   context 'Hmong asia(N) people', jira: 'VUF-1245' do
@@ -70,8 +70,8 @@ describe 'Subject Search' do
   context 'home schooling vs home and school', jira: 'VUF-1353' do
     it 'home schooling' do
       resp = solr_resp_doc_ids_only(subject_search_args '"home schooling"')
-      expect(resp.size).to be >= 500
-      expect(resp.size).to be <= 625
+      expect(resp.size).to be >= 600
+      expect(resp.size).to be <= 675
       expect(resp).to include('8834110')
     end
     it 'home and school' do
@@ -171,7 +171,7 @@ describe 'Subject Search' do
         resp = solr_resp_doc_ids_only(subject_search_args('"Older people abuse of"').merge('rows' => 100))
         expect(resp).to include(%w(4544375 11417477))
         expect(resp).not_to include('7631176')
-        expect(resp.size).to be <= 225
+        expect(resp.size).to be <= 235
       end
       it 'Older people > Abuse of > Illinois > Prevention.' do
         resp = solr_resp_doc_ids_only(subject_search_args '"Older people abuse of illinois prevention"')

--- a/spec/synonym_spec.rb
+++ b/spec/synonym_spec.rb
@@ -104,8 +104,7 @@ describe "Tests for synonyms.txt used by Solr SynonymFilterFactory" do
       end
       it "professional C++" do
         resp = solr_resp_ids_from_query('professional C++')
-        # ckey 7534583 doesn't exist anymore; replaced with ckey 11728202
-        expect(resp).to include(['9612289', '9240287', '11728202', '8257317', '9801531']).in_first(10).results
+        expect(resp).to include(['9612289', '9240287', '11728202', '8257317', '12422871']).in_first(10).results
         expect(resp.size).to be <= 150
         expect(resp).not_to have_the_same_number_of_results_as(solr_resp_ids_from_query "professional C")
       end

--- a/spec/synonym_spec.rb
+++ b/spec/synonym_spec.rb
@@ -166,7 +166,7 @@ describe "Tests for synonyms.txt used by Solr SynonymFilterFactory" do
 
       it "a#" do
         resp = solr_resp_ids_from_query('a#')
-        expect(resp.size).to be <= 1825  # should not include a as well, only a sharp
+        expect(resp.size).to be <= 1900  # should not include a as well, only a sharp
       end
       it "a# - title search" do
         resp = solr_resp_doc_ids_only(title_search_args('a#'))
@@ -175,7 +175,7 @@ describe "Tests for synonyms.txt used by Solr SynonymFilterFactory" do
       it "c# minor" do
         resp = solr_response({'q' => 'c# minor', 'fl'=>'id,title_display', 'facet'=>false})
         expect(resp).to include("title_display" => /c(#|♯|\-sharp| sharp) minor/i).in_each_of_first(10).documents
-        expect(resp.size).to be <= 3350
+        expect(resp.size).to be <= 3500
         expect(resp).to have_the_same_number_of_results_as(solr_resp_ids_from_query('C♯ minor'))
         expect(resp).to have_the_same_number_of_results_as(solr_resp_ids_from_query('C-sharp minor'))
         # would also match  c ... minor ... sharp
@@ -262,7 +262,7 @@ describe "Tests for synonyms.txt used by Solr SynonymFilterFactory" do
         it "a short sharp (qs = 1)" do
           resp = solr_resp_ids_from_query('a short sharp')
           expect(resp).to include('3965729').as_first.document # A short, sharp shock / Kim Stanley Robinson.
-          expect(resp.size).to be <= 1300
+          expect(resp.size).to be <= 1350
         end
         it "B sharp - title" do
           resp = solr_resp_doc_ids_only(title_search_args('b sharp'))
@@ -376,7 +376,7 @@ describe "Tests for synonyms.txt used by Solr SynonymFilterFactory" do
         it "a flat world - title search" do
           resp = solr_response(title_search_args('a flat world').merge!({'fl'=>'id,title_display', 'facet'=>false}))
           expect(resp).to include("title_display" => /a flat world/i).in_each_of_first(5).documents
-          expect(resp.size).to be <= 125
+          expect(resp.size).to be <= 135
         end
         it "a bent flat (qs = 1)" do
           resp = solr_resp_ids_from_query('a bent flat')


### PR DESCRIPTION
I spot-checked some of the bigger number changes by limited on the `date_cataloged` window and the numbers seemed to checked out.

I marked one test as pending that probably deserves expert review (a query for `강물 이 될 때 까지` used to return 1 document, now returns 2). I assume the 2nd doc is probably relevant, but 🤷‍♂️ 

There's also a facets_spec count for `Thesis/Dissertation|Master's` that's somehow went /down/, so I left it failing in case you wanted to investigate further.