### PR TITLE
Modifies our "OR" boolean tests to match SearchWorks queries

### DIFF
--- a/spec/advanced_search_spec.rb
+++ b/spec/advanced_search_spec.rb
@@ -200,8 +200,7 @@ describe 'advanced search' do
         expect(@author_resp).to have_the_same_number_of_results_as(solr_resp_doc_ids_only(author_search_args('stalin')))
       end
       it 'title rechi OR sochineniia' do
-        resp = solr_resp_doc_ids_only({ 'q' => "#{title_query('rechi OR sochineniia')}" }.merge(solr_args))
-        expect(resp).to have_the_same_number_of_results_as(solr_resp_doc_ids_only(title_search_args('rechi OR sochineniia')))
+        resp = solr_resp_doc_ids_only({ 'q' => "#{title_query_or('rechi OR sochineniia')}" }.merge(solr_args))
         expect(resp.size).to be >= 2200
         expect(resp.size).to be <= 2400
       end
@@ -218,7 +217,7 @@ describe 'advanced search' do
         expect(resp.size).to be <= 12
       end
       it 'author and title both terms optional' do
-        resp = solr_resp_doc_ids_only({ 'q' => "#{author_query('stalin')} AND #{title_query('rechi OR sochineniia')}" }.merge(solr_args))
+        resp = solr_resp_doc_ids_only({ 'q' => "#{author_query('stalin')} AND #{title_query_or('rechi OR sochineniia')}" }.merge(solr_args))
         expect(resp).to have_fewer_results_than @author_resp
         expect(resp.size).to be >= 20
         expect(resp.size).to be <= 30
@@ -439,7 +438,12 @@ describe 'advanced search' do
   end
 
   def title_query(terms)
-    '_query_:"{!edismax qf=$qf_title pf=$pf_title pf3=$pf3_title pf2=$pf2_title}' + terms + '"'
+    "_query_:\"{!edismax qf=$qf_title pf=$pf_title pf3=$pf3_title pf2=$pf2_title}#{terms}\""
+  end
+
+  # Blacklight Advanced Search uses a modified query for OR queries
+  def title_query_or(terms)
+    "_query_:\"{!dismax qf=$qf_title pf=$pf_title pf3=$pf3_title pf2=$pf2_title mm=1}#{terms}\""
   end
 
   def author_query(terms)

--- a/spec/boolean_spec.rb
+++ b/spec/boolean_spec.rb
@@ -207,7 +207,10 @@ describe 'boolean operators' do
     context 'actual user queries' do
       context 'indochine OR indochina' do
         before(:all) do
-          @indochine_or_indochina = solr_resp_ids_from_query 'indochine OR indochina'
+          @indochine_or_indochina = solr_resp_doc_ids_only(
+            q: '_query_:"{!dismax pf2=$p2 pf3=$pf3  mm=1}indochine OR indochina"',
+            defType: 'lucene'
+          )
           @indochine = solr_resp_ids_from_query 'indochine' # 513 docs  2013-05-21
           @indochina = solr_resp_ids_from_query 'indochina' # 1522 docs  2013-05-21
         end
@@ -253,7 +256,14 @@ describe 'boolean operators' do
 
     it 'lesbian OR gay videos', jira: ['VUF-300', 'VUF-301', 'VUF-311'] do
       # eloader records cause results to explode; add access facet to keep expected results stable
-      resp = solr_resp_doc_ids_only('q' => 'lesbian OR gay', 'fq' => 'format:("Video"), access_facet:("At the Library")')
+      resp = solr_resp_doc_ids_only(
+        'q' => '_query_:"{!dismax pf2=$p2 pf3=$pf3 mm=1}lesbian OR gay"',
+        'defType' => 'lucene',
+        'fq' => [
+          'format:("Video")',
+          'access_facet:("At the Library")'
+        ]
+      )
       expect(resp.size).to be >= 1200
       expect(resp.size).to be <= 1400
     end


### PR DESCRIPTION
Our previous practice in sw_index_tests relied on Solr 4.x boolean logic
but was not actually testing the queries that SearchWorks executes when
it comes to "OR" boolean logic. This commit fixes that by using the
correct query parser and providing the mm values that are modified
by the Blacklight Advanced Search plugin.

Fixes #193, Fixes #191